### PR TITLE
Fix file permissions in .deb

### DIFF
--- a/scripts/build-linux-docker.sh
+++ b/scripts/build-linux-docker.sh
@@ -480,6 +480,7 @@ EOF
     find fujisan-linux -type d -exec chmod 755 {} \;
     find fujisan-linux -type f -exec chmod 644 {} \;
     chmod 755 fujisan-linux/usr/bin/fujisan
+    chmod 755 fujisan-linux/usr/lib/fujisan/Fujisan
     
     # Build .deb package
     dpkg-deb --build fujisan-linux "fujisan_${VERSION_CLEAN}_${ARCH}.deb"


### PR DESCRIPTION
The cleanup of file permissions in the .deb setup was removing the execute bit from the "real" binary in /usr/lib/fujisan/Fujisan, causing the forwarding script to fail when installed from the .deb package.

This didn't affect the .tar.gz package which was and remains fine.

Gets the main emulator running from the .deb package, though it looks like there are further tweaks needed to pull in fujinet-pc which I might take a look at later.

Fixes https://github.com/pedgarcia/fujisan/issues/18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux package build configuration to ensure proper installation on Debian-based systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->