### PR TITLE
libatari800: precise per-instruction PC breakpoints over the TCP debug API

### DIFF
--- a/include/atariemulator.h
+++ b/include/atariemulator.h
@@ -479,6 +479,7 @@ private:
     bool m_breakpointsEnabled = true;
     unsigned short m_lastPC = 0xFFFF;  // Track last PC for breakpoint detection
     void checkBreakpoints();  // Internal breakpoint checking
+    void syncBreakpointsToCore();  // Push Qt breakpoint set into libatari800's per-instruction table
     
     // Disk drive tracking
     QString m_diskImages[8]; // Paths for D1: through D8:

--- a/patches/0019-libatari800-pc-breakpoints.patch
+++ b/patches/0019-libatari800-pc-breakpoints.patch
@@ -1,0 +1,186 @@
+From 549865c39dcdff63c4145850bfcbd56c57331ee7 Mon Sep 17 00:00:00 2001
+From: Fujisan <fujisan@8bitrelics.com>
+Date: Mon, 6 Jul 2026 00:00:00 -0700
+Subject: [PATCH] libatari800: add PC breakpoint API for per-instruction
+ debugging
+
+Expose the atari800 core's per-instruction PC breakpoint table
+(MONITOR_breakpoint_table[]) to libatari800 clients via a new
+libatari800_set_pc_breakpoints() call, and make a breakpoint hit return
+control to the host instead of terminating the process.
+
+libatari800 has no interactive monitor, so the core's DO_BREAK path
+(ENTER_MONITOR -> Atari800_Exit(TRUE)) would call exit(0) once a breakpoint
+fired. Instead, PLATFORM_Exit() now longjmps back into
+libatari800_next_frame() (via libatari800_monitor_jmp), which returns early
+with the CPU parked exactly at the breakpoint PC and libatari800_break_hit set.
+
+Built with MONITOR_BREAK/MONITOR_BREAKPOINTS enabled, this gives debuggers
+one-shot PC breakpoint precision instead of only detecting breakpoints at
+frame boundaries.
+---
+ src/libatari800/api.c         | 63 ++++++++++++++++++++++++++++++++---
+ src/libatari800/exit.c        | 21 ++++++++++++
+ src/libatari800/libatari800.h |  8 +++++
+ 3 files changed, 87 insertions(+), 5 deletions(-)
+
+diff --git a/src/libatari800/api.c b/src/libatari800/api.c
+index 4b8db15c..7ba672b4 100644
+--- a/src/libatari800/api.c
++++ b/src/libatari800/api.c
+@@ -45,6 +45,7 @@
+ #include "screen.h"
+ #include "sio.h"
+ #include "../sound.h"
++#include "../monitor.h"
+ #include "util.h"
+ #include "libatari800/main.h"
+ #include "libatari800/cpu_crash.h"
+@@ -57,7 +58,18 @@
+ 
+ #ifdef HAVE_SETJMP
+ jmp_buf libatari800_cpu_crash;
++/* Landing pad for a debugger PC breakpoint (see PLATFORM_Exit()). libatari800
++   has no interactive monitor, so when the CPU core hits a breakpoint we longjmp
++   back here to return control to the host with the CPU parked at the break PC,
++   rather than terminating the process via exit(0). */
++jmp_buf libatari800_monitor_jmp;
++/* Non-zero while inside LIBATARI800_Frame(); tells PLATFORM_Exit() it is safe to
++   longjmp back into libatari800_next_frame() instead of exiting. */
++int libatari800_monitor_active = 0;
+ #endif
++/* Set to non-zero by libatari800_next_frame() when the frame ended because a
++   debugger PC breakpoint fired (as opposed to completing normally). */
++int libatari800_break_hit = 0;
+ 
+ /* global variable indicating that BRK instruction should exit emulation */
+ int libatari800_continue_on_brk = 0;
+@@ -224,12 +236,29 @@ int libatari800_next_frame(input_template_t *input)
+ #endif /* HAVE_SETJMP */
+ 	{
+ 		/* normal operation */
+-		LIBATARI800_Frame();
+-		if (CPU_cim_encountered) {
+-			libatari800_error_code = LIBATARI800_CPU_CRASH;
++		libatari800_break_hit = 0;
++#ifdef HAVE_SETJMP
++		if (setjmp(libatari800_monitor_jmp) != 0) {
++			/* A debugger PC breakpoint fired; the CPU is parked at the break
++			   PC (CPU_regPC). Return early so the host can inspect state. */
++			libatari800_break_hit = 1;
+ 		}
+-		else if (ANTIC_dlist == 0) {
+-			libatari800_error_code = LIBATARI800_DLIST_ERROR;
++		else
++#endif /* HAVE_SETJMP */
++		{
++#ifdef HAVE_SETJMP
++			libatari800_monitor_active = 1;
++#endif
++			LIBATARI800_Frame();
++#ifdef HAVE_SETJMP
++			libatari800_monitor_active = 0;
++#endif
++			if (CPU_cim_encountered) {
++				libatari800_error_code = LIBATARI800_CPU_CRASH;
++			}
++			else if (ANTIC_dlist == 0) {
++				libatari800_error_code = LIBATARI800_DLIST_ERROR;
++			}
+ 		}
+ 	}
+ 	PLATFORM_DisplayScreen();
+@@ -589,6 +618,30 @@ int libatari800_execute_cycles(int target_cycles)
+ 	return cycles_executed;
+ }
+ 
++/* Set the PC breakpoint list for the debugger (per-instruction precision).
++ * Populates the atari800 core's MONITOR_breakpoint_table[] with PC-equals
++ * conditions so CPU_GO() halts (PC--; DO_BREAK -> Atari800_Exit) exactly at a
++ * breakpoint address, causing libatari800_next_frame() to return early parked
++ * at that PC. Passing count <= 0 disables all breakpoints. */
++void libatari800_set_pc_breakpoints(const unsigned short *addrs, int count)
++{
++#ifdef MONITOR_BREAKPOINTS
++	int i;
++	if (count < 0) count = 0;
++	if (count > MONITOR_BREAKPOINT_TABLE_MAX) count = MONITOR_BREAKPOINT_TABLE_MAX;
++	for (i = 0; i < count; i++) {
++		MONITOR_breakpoint_table[i].enabled   = TRUE;
++		MONITOR_breakpoint_table[i].condition = MONITOR_BREAKPOINT_PC | MONITOR_BREAKPOINT_EQUAL;
++		MONITOR_breakpoint_table[i].value     = addrs[i];
++		MONITOR_breakpoint_table[i].m_addr    = 0;
++	}
++	MONITOR_breakpoint_table_size = count;
++	MONITOR_breakpoints_enabled   = (count > 0) ? 1 : 0;
++#else
++	(void)addrs; (void)count;
++#endif
++}
++
+ /*
+ vim:ts=4:sw=4:
+ */
+diff --git a/src/libatari800/exit.c b/src/libatari800/exit.c
+index b9cf7955..f8a759fc 100644
+--- a/src/libatari800/exit.c
++++ b/src/libatari800/exit.c
+@@ -26,10 +26,20 @@
+ #include "config.h"
+ #include <stdio.h>
+ #include <string.h>
++#ifdef HAVE_SETJMP
++#include <setjmp.h>
++#endif
+ 
+ /* Atari800 includes */
+ #include "log.h"
+ 
++#ifdef HAVE_SETJMP
++/* Defined in api.c: landing pad and guard used to return control to the host
++   when the CPU core enters the monitor (e.g. a debugger PC breakpoint). */
++extern jmp_buf libatari800_monitor_jmp;
++extern int libatari800_monitor_active;
++#endif
++
+ 
+ /* This is placed in a separate file so other programs that include this code
+  in their own makefile can redefine this function and point to their own
+@@ -40,6 +50,17 @@ int PLATFORM_Exit(int run_monitor)
+ {
+ 	Log_flushlog();
+ 
++#ifdef HAVE_SETJMP
++	if (run_monitor && libatari800_monitor_active) {
++		/* A monitor break (debugger PC breakpoint) fired during a frame.
++		   libatari800 has no interactive monitor, so instead of terminating
++		   the process, longjmp back into libatari800_next_frame(), leaving the
++		   CPU parked at the break PC for the host to inspect. */
++		libatari800_monitor_active = 0;
++		longjmp(libatari800_monitor_jmp, 1);
++	}
++#endif
++
+ 	return 0;  /* always exit. There is no monitor in libatari800 */
+ }
+ 
+diff --git a/src/libatari800/libatari800.h b/src/libatari800/libatari800.h
+index eb5ed5da..42c575ee 100644
+--- a/src/libatari800/libatari800.h
++++ b/src/libatari800/libatari800.h
+@@ -319,4 +319,12 @@ int libatari800_set_sio_patch_enabled(int enabled);
+ /* Partial frame execution for fine-grained debugging */
+ int libatari800_execute_cycles(int target_cycles);
+ 
++/* Set the debugger PC breakpoint list (per-instruction precision).
++ * addrs points to count 16-bit addresses; count <= 0 disables all breakpoints. */
++void libatari800_set_pc_breakpoints(const unsigned short *addrs, int count);
++
++/* Non-zero if the most recent libatari800_next_frame() returned early because a
++ * debugger PC breakpoint fired (CPU parked at the breakpoint PC). */
++extern int libatari800_break_hit;
++
+ #endif /* LIBATARI800_H_ */
+-- 
+2.43.0
+

--- a/patches/CHANGES.md
+++ b/patches/CHANGES.md
@@ -1,5 +1,39 @@
 # Patch System Changes
 
+## 0019-libatari800-pc-breakpoints.patch (July 2026)
+
+**Problem:** Fujisan runs the CPU a whole frame at a time via
+`libatari800_next_frame()` and only checks breakpoints at frame boundaries, so
+PC breakpoints on one-shot addresses (e.g. a program's entry point) are sailed
+past and never hit. The atari800 core has a correct per-instruction PC
+breakpoint table (`MONITOR_breakpoint_table[]`), but the `libatari800` configure
+preset forces `MONITOR_BREAK`/`MONITOR_BREAKPOINTS` off, and even with them on
+the core's break path (`DO_BREAK` -> `ENTER_MONITOR` -> `Atari800_Exit(TRUE)`)
+calls `exit(0)` in libatari800 because `PLATFORM_Exit()` "always exits - there is
+no monitor in libatari800". A breakpoint would therefore terminate the process.
+
+**Fix (three parts):**
+1. `libatari800_set_pc_breakpoints(const unsigned short *addrs, int count)` in
+   `api.c` (declared in `libatari800.h`) populates `MONITOR_breakpoint_table[]`
+   with PC-equals conditions so the CPU core halts every-instruction at a
+   breakpoint. `count <= 0` disables all breakpoints.
+2. `PLATFORM_Exit()` (`exit.c`) no longer terminates on a monitor break: when a
+   break fires inside a frame it `longjmp`s back into `libatari800_next_frame()`
+   (landing pad `libatari800_monitor_jmp`, guarded by `libatari800_monitor_active`),
+   returning early with the CPU parked exactly at the breakpoint PC and
+   `libatari800_break_hit` set.
+3. The build must enable the core defines - `scripts/configure-atari800.sh`
+   patches `src/config.h` to `#define MONITOR_BREAK 1` / `MONITOR_BREAKPOINTS 1`
+   after `./configure` (they are forced off by the libatari800 target preset).
+
+Fujisan wires its Qt breakpoint set into the table via
+`AtariEmulator::syncBreakpointsToCore()` and arms a loaded program's entry point
+during `loadXexForDebug()` so the debugger parks precisely at the first
+instruction. BRK handling is unaffected (libatari800 traps BRK via
+`longjmp(libatari800_cpu_crash, ...)`, not `DO_BREAK`).
+
+---
+
 ## 0015-netsio-recover-stale-sio-transaction.patch (April 2026)
 
 **Problem:** After a cold boot (or similar), `TransferStatus` in `sio.c` can

--- a/scripts/configure-atari800.sh
+++ b/scripts/configure-atari800.sh
@@ -195,6 +195,14 @@ else
     # Unix/macOS: Use full configuration
     # Disable MP3 support to avoid libmp3lame dependency (users can still record to WAV/PCM)
     ./configure --target=libatari800 --enable-netsio --with-mp3=no
+
+    # Enable per-instruction code breakpoints (forced off by the libatari800 target preset).
+    # This activates the atari800 core's MONITOR_breakpoint_table[] so the CPU halts
+    # (via Atari800_Exit) precisely at a PC breakpoint, letting libatari800_next_frame()
+    # return early parked at the breakpoint. Fujisan's post-frame checkBreakpoints() then
+    # sees the correct PC. See patches/0019-libatari800-pc-breakpoints.patch.
+    sed -i.bak 's|/\* #undef MONITOR_BREAK \*/|#define MONITOR_BREAK 1|' src/config.h
+    sed -i.bak 's|/\* #undef MONITOR_BREAKPOINTS \*/|#define MONITOR_BREAKPOINTS 1|' src/config.h
 fi
 
 echo "atari800 configuration completed"

--- a/src/atariemulator.cpp
+++ b/src/atariemulator.cpp
@@ -2963,6 +2963,48 @@ int AtariEmulator::getCurrentEmulationSpeed() const
 }
 
 
+// Parse an Atari executable (XEX/COM/EXE) header and return its run address
+// (RUNAD, the two bytes destined for $02E0/$02E1), or 0 if none is present.
+// This lets loadXexForDebug arm the entry point in the CPU breakpoint table
+// BEFORE the binary loader auto-runs the program, so we halt exactly at entry.
+static unsigned short parseXexRunAddress(const QString& filename)
+{
+    QFile f(filename);
+    if (!f.open(QIODevice::ReadOnly)) {
+        return 0;
+    }
+    QByteArray d = f.readAll();
+    f.close();
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(d.constData());
+    int n = d.size();
+    int i = 0;
+    if (n >= 2 && p[0] == 0xFF && p[1] == 0xFF) {
+        i = 2;  // skip leading $FFFF marker
+    }
+    unsigned short runad = 0;
+    while (i + 4 <= n) {
+        // Optional $FFFF marker may separate segments
+        if (p[i] == 0xFF && p[i + 1] == 0xFF) {
+            i += 2;
+            continue;
+        }
+        int start = p[i] | (p[i + 1] << 8);
+        int end   = p[i + 2] | (p[i + 3] << 8);
+        i += 4;
+        int len = end - start + 1;
+        if (len <= 0 || i + len > n) {
+            break;
+        }
+        // RUNAD lives at $02E0/$02E1; capture it if this segment covers it
+        if (start <= 0x2E0 && end >= 0x2E1) {
+            int off = i + (0x2E0 - start);
+            runad = p[off] | (p[off + 1] << 8);
+        }
+        i += len;
+    }
+    return runad;
+}
+
 bool AtariEmulator::loadXexForDebug(const QString& filename)
 {
     // libatari800_reboot_with_file() calls Atari800_Coldstart() which sends a 0xFF
@@ -2992,50 +3034,69 @@ bool AtariEmulator::loadXexForDebug(const QString& filename)
         return false;
     }
     
-    // Step frames until loading completes (max 120 frames = 2 seconds at 60fps)
+    // Step frames until the program reaches its entry point (max 120 frames =
+    // 2 seconds at 60fps). As soon as the loader populates the entry vector
+    // (RUNAD, or INITAD as a fallback) we arm it in libatari800's per-instruction
+    // breakpoint table, so the CPU halts EXACTLY at the entry point rather than
+    // overshooting it by a whole frame's worth of instructions. This leaves the
+    // debugger parked precisely at the first instruction of the loaded program,
+    // which is what a one-shot entry-point breakpoint expects.
     const int maxFrames = 120;
     int framesProcessed = 0;
     bool loadingComplete = false;
-    
-    
+    bool entryArmed = false;
+    unsigned short armedEntry = 0;
+
+    // Pre-arm the entry point from the file's RUNAD BEFORE any frame runs. The
+    // binary loader auto-runs the program (JSR RUNAD) during loading, so arming
+    // only after detecting the vector in memory would race and miss it. With the
+    // breakpoint already in the core table, the CPU halts precisely when the
+    // loaded program first executes its entry instruction.
+    unsigned short fileEntry = parseXexRunAddress(filename);
+    if (fileEntry != 0x0000 && fileEntry != 0xFFFF) {
+        armedEntry = fileEntry;
+        libatari800_set_pc_breakpoints(&armedEntry, 1);
+        entryArmed = true;
+    }
+
     while (framesProcessed < maxFrames) {
-        // Process one frame to advance the loading
+        // Process one frame to advance the loading. Once the entry point is
+        // armed, this returns early the instant the CPU core reaches it.
         processFrame();
         framesProcessed++;
-        
-        // Check if loading has completed
-        // BINLOAD_start_binloading is set to TRUE when loading starts and FALSE when done
-        if (!BINLOAD_start_binloading) {
-            // Also verify RUNAD or INITAD is set
-            unsigned short runad = mem[0x2E0] | (mem[0x2E1] << 8);
-            unsigned short initad = mem[0x2E2] | (mem[0x2E3] << 8);
-            
-            if ((runad != 0x0000 && runad != 0xFFFF) || 
-                (initad != 0x0000 && initad != 0xFFFF)) {
-                loadingComplete = true;
-                break;
-            }
+
+        // Determine the entry vector once the loader has populated it.
+        unsigned short runad = mem[0x2E0] | (mem[0x2E1] << 8);
+        unsigned short initad = mem[0x2E2] | (mem[0x2E3] << 8);
+        unsigned short entry = 0;
+        if (runad != 0x0000 && runad != 0xFFFF) {
+            entry = runad;
+        } else if (initad != 0x0000 && initad != 0xFFFF) {
+            entry = initad;
         }
-        
-        // For initial frames, BINLOAD_start_binloading might not be set yet
-        // So also check if vectors become valid
-        if (framesProcessed > 10) {
-            unsigned short runad = mem[0x2E0] | (mem[0x2E1] << 8);
-            unsigned short initad = mem[0x2E2] | (mem[0x2E3] << 8);
-            
-            if ((runad != 0x0000 && runad != 0xFFFF) || 
-                (initad != 0x0000 && initad != 0xFFFF)) {
-                // Vectors are set, check if we're past the loader
-                if (CPU_regPC < 0xD000 || CPU_regPC >= 0xE000) {
-                    // PC is not in ROM loader area, likely done
-                    loadingComplete = true;
-                    break;
-                }
-            }
+
+        // Arm the entry point in the core breakpoint table as soon as we know it,
+        // so execution halts precisely when the loaded program first runs.
+        if (!entryArmed && entry != 0) {
+            armedEntry = entry;
+            libatari800_set_pc_breakpoints(&armedEntry, 1);
+            entryArmed = true;
+        }
+
+        // Halted precisely at the entry point (the core breakpoint fired and
+        // libatari800_next_frame() returned early parked at that PC).
+        if (entryArmed && CPU_regPC == armedEntry) {
+            loadingComplete = true;
+            break;
         }
     }
-    
-    // Pause execution now that loading is complete (or timeout)
+
+    // Remove the temporary entry-point breakpoint. The core table now reflects
+    // only user-defined breakpoints (empty unless the caller added some), so a
+    // subsequent add_breakpoint + resume behaves predictably.
+    syncBreakpointsToCore();
+
+    // Pause execution now that we're parked at the entry point (or timed out).
     pauseEmulation();
     
     // Read the entry point vectors
@@ -4140,6 +4201,7 @@ void AtariEmulator::addBreakpoint(unsigned short address)
 {
     if (!m_breakpoints.contains(address)) {
         m_breakpoints.insert(address);
+        syncBreakpointsToCore();
         emit breakpointAdded(address);
     }
 }
@@ -4147,6 +4209,7 @@ void AtariEmulator::addBreakpoint(unsigned short address)
 void AtariEmulator::removeBreakpoint(unsigned short address)
 {
     if (m_breakpoints.remove(address)) {
+        syncBreakpointsToCore();
         emit breakpointRemoved(address);
     }
 }
@@ -4155,6 +4218,7 @@ void AtariEmulator::clearAllBreakpoints()
 {
     if (!m_breakpoints.isEmpty()) {
         m_breakpoints.clear();
+        syncBreakpointsToCore();
         emit breakpointsCleared();
     }
 }
@@ -4172,6 +4236,22 @@ QSet<unsigned short> AtariEmulator::getBreakpoints() const
 void AtariEmulator::setBreakpointsEnabled(bool enabled)
 {
     m_breakpointsEnabled = enabled;
+    syncBreakpointsToCore();
+}
+
+// Push the Qt-side breakpoint set into libatari800's per-instruction PC breakpoint
+// table so the CPU core halts (via Atari800_Exit) precisely at the breakpoint PC,
+// returning early from libatari800_next_frame(). This gives one-shot PC breakpoints
+// instruction-level precision instead of only being caught at frame boundaries.
+void AtariEmulator::syncBreakpointsToCore()
+{
+    std::vector<unsigned short> v;
+    if (m_breakpointsEnabled) {
+        for (unsigned short a : m_breakpoints) {
+            v.push_back(a);
+        }
+    }
+    libatari800_set_pc_breakpoints(v.empty() ? nullptr : v.data(), (int)v.size());
 }
 
 bool AtariEmulator::areBreakpointsEnabled() const


### PR DESCRIPTION
## Summary

Driving Fujisan over the TCP debug API, PC breakpoints on **one-shot addresses**
(a program's entry point, or any line executed once) are never hit — execution
sails straight past them. Breakpoints only fire on addresses the CPU hits
repeatedly (e.g. a wait loop). This makes "stop at a specific line" — the core
debugger use case — unreliable for external tooling.

**Root cause:** Fujisan advances the CPU a whole frame at a time via
`libatari800_next_frame()` and samples breakpoints only at frame (or 500-cycle)
boundaries, so a one-shot PC between boundaries is skipped. The atari800 core has
a correct *per-instruction* PC breakpoint table (`MONITOR_breakpoint_table[]`,
checked inside `CPU_GO`), but:
- the `libatari800` configure preset forces `MONITOR_BREAK` /
  `MONITOR_BREAKPOINTS` **off**, so the table is compiled out; and
- even enabled, a break takes `DO_BREAK → ENTER_MONITOR → Atari800_Exit(TRUE)`,
  which in libatari800 calls `exit(0)` ("no monitor in libatari800") — so a
  breakpoint would terminate the process.

## The fix

A new core patch, `patches/0019-libatari800-pc-breakpoints.patch`, plus Fujisan
wiring:

1. **`libatari800_set_pc_breakpoints(const unsigned short *addrs, int count)`**
   (`api.c`, declared in `libatari800.h`) populates `MONITOR_breakpoint_table[]`
   with PC-equals conditions; `count <= 0` disables all breakpoints.
2. **`PLATFORM_Exit()`** (`exit.c`) no longer terminates on a monitor break: it
   `longjmp`s back into `libatari800_next_frame()` (landing pad
   `libatari800_monitor_jmp`, guarded by `libatari800_monitor_active`), returning
   early with the CPU parked exactly at the breakpoint PC and
   `libatari800_break_hit` set. This mirrors the existing `libatari800_cpu_crash`
   setjmp pattern.
3. **`scripts/configure-atari800.sh`** enables the core defines by patching the
   generated `src/config.h` (`#define MONITOR_BREAK 1` / `MONITOR_BREAKPOINTS 1`)
   after `./configure`, since the `libatari800` target preset forces them off.
4. **`AtariEmulator::syncBreakpointsToCore()`** mirrors the Qt breakpoint set into
   the core table on add/remove/clear/enable; **`loadXexForDebug()`** arms the
   loaded program's entry point (parsed RUNAD) so the debugger parks precisely at
   the first instruction instead of overshooting it.

## Validation

Over the TCP API, loading a program and setting a one-shot PC breakpoint at the
entry point (and at an instruction in the program body) now halts **exactly** at
the target address, where before it was missed. A VS Code source-level debugger
mapping C/C++ source lines to addresses drives this end-to-end (breakpoints,
stepping, variables). BRK handling is unaffected — libatari800 traps BRK via
`longjmp(libatari800_cpu_crash, ...)`, not `DO_BREAK`.

## Files

- `patches/0019-libatari800-pc-breakpoints.patch` (core: api.c, exit.c, libatari800.h)
- `scripts/configure-atari800.sh` (enable MONITOR_BREAK/BREAKPOINTS)
- `src/atariemulator.cpp`, `include/atariemulator.h` (Qt wiring + entry-point arming)
- `patches/CHANGES.md` (changelog entry)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Debugger now stops precisely at a program’s entry point for XEX/COM/EXE launches.
  - Breakpoints are now synced more reliably so changes take effect immediately during emulation.

- **Bug Fixes**
  - Fixed cases where breakpoints could be missed at frame boundaries.
  - Improved breakpoint handling so hitting a debugger breakpoint returns control to the app instead of ending emulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->