### PR TITLE
Fix/debugger breakpoints and stepping

### DIFF
--- a/include/atariemulator.h
+++ b/include/atariemulator.h
@@ -135,6 +135,9 @@ extern "C" {
     
     // Single-instruction stepping for debugger
     extern void libatari800_step_instruction(void);
+
+    // True single-instruction step (injected by scripts/configure-atari800.sh)
+    extern void libatari800_debug_step_instruction(void);
     
     // NOTE: libatari800_exit and Atari800_InitialiseMachine are already declared
     // in libatari800.h and atari.h respectively, so we don't redeclare them here

--- a/patches/0019-libatari800-pc-breakpoints.patch
+++ b/patches/0019-libatari800-pc-breakpoints.patch
@@ -90,29 +90,46 @@ index 4b8db15c..7ba672b4 100644
  		}
  	}
  	PLATFORM_DisplayScreen();
-@@ -589,6 +618,30 @@ int libatari800_execute_cycles(int target_cycles)
+@@ -589,6 +618,47 @@ int libatari800_execute_cycles(int target_cycles)
  	return cycles_executed;
  }
  
 +/* Set the PC breakpoint list for the debugger (per-instruction precision).
-+ * Populates the atari800 core's MONITOR_breakpoint_table[] with PC-equals
-+ * conditions so CPU_GO() halts (PC--; DO_BREAK -> Atari800_Exit) exactly at a
-+ * breakpoint address, causing libatari800_next_frame() to return early parked
-+ * at that PC. Passing count <= 0 disables all breakpoints. */
++ *
++ * The core's breakpoint table is an AND/OR expression list, not a flat list of
++ * addresses: entries are ANDed together, and an entry whose condition is
++ * MONITOR_BREAKPOINT_OR separates alternatives (see cpu.c -- reaching such an
++ * entry means the preceding group matched, so the breakpoint fires). Writing
++ * several bare PC conditions therefore means "PC == a AND PC == b", which is
++ * never true, so with two or more breakpoints set none of them would ever fire.
++ * Emit an OR separator between addresses.
++ *
++ * Passing count <= 0 disables all breakpoints. */
 +void libatari800_set_pc_breakpoints(const unsigned short *addrs, int count)
 +{
 +#ifdef MONITOR_BREAKPOINTS
 +	int i;
++	int n = 0;
++	/* each extra breakpoint also costs one OR separator entry */
++	int max = (MONITOR_BREAKPOINT_TABLE_MAX + 1) / 2;
 +	if (count < 0) count = 0;
-+	if (count > MONITOR_BREAKPOINT_TABLE_MAX) count = MONITOR_BREAKPOINT_TABLE_MAX;
++	if (count > max) count = max;
 +	for (i = 0; i < count; i++) {
-+		MONITOR_breakpoint_table[i].enabled   = TRUE;
-+		MONITOR_breakpoint_table[i].condition = MONITOR_BREAKPOINT_PC | MONITOR_BREAKPOINT_EQUAL;
-+		MONITOR_breakpoint_table[i].value     = addrs[i];
-+		MONITOR_breakpoint_table[i].m_addr    = 0;
++		if (i > 0) {
++			MONITOR_breakpoint_table[n].enabled   = TRUE;
++			MONITOR_breakpoint_table[n].condition = MONITOR_BREAKPOINT_OR;
++			MONITOR_breakpoint_table[n].value     = 0;
++			MONITOR_breakpoint_table[n].m_addr    = 0;
++			n++;
++		}
++		MONITOR_breakpoint_table[n].enabled   = TRUE;
++		MONITOR_breakpoint_table[n].condition = MONITOR_BREAKPOINT_PC | MONITOR_BREAKPOINT_EQUAL;
++		MONITOR_breakpoint_table[n].value     = addrs[i];
++		MONITOR_breakpoint_table[n].m_addr    = 0;
++		n++;
 +	}
-+	MONITOR_breakpoint_table_size = count;
-+	MONITOR_breakpoints_enabled   = (count > 0) ? 1 : 0;
++	MONITOR_breakpoint_table_size = n;
++	MONITOR_breakpoints_enabled   = (n > 0) ? 1 : 0;
 +#else
 +	(void)addrs; (void)count;
 +#endif

--- a/patches/CHANGES.md
+++ b/patches/CHANGES.md
@@ -1,5 +1,43 @@
 # Patch System Changes
 
+## Single-instruction stepping (July 2026)
+
+**Problem:** `AtariEmulator::stepOneInstruction()` did not step an instruction --
+it called `libatari800_next_frame()`, executing thousands of instructions per
+"step" (its comment claimed no patch was available for true single stepping).
+This silently broke debugging over the TCP API: to resume from a breakpoint a
+debugger must lift that breakpoint and step one instruction off it, so a
+frame-sized step runs past every other breakpoint in that frame. Source-level
+stepping also jumped to essentially arbitrary lines, and `debug.step_over`
+(which loops `stepOneInstruction()` until it reaches the return address) could
+never converge.
+
+`patches/0003-single-instruction-stepping.patch` was meant to provide
+`libatari800_step_instruction()`, but it is not applied in the current build and
+its implementation is itself broken: `CPU_GO(20)` executes nothing whenever the
+CPU is already past cycle 20 of the current scanline, because CPU_GO() runs
+while `ANTIC_xpos < limit`. A step built on it is a silent no-op.
+
+**Fix:** `scripts/configure-atari800.sh` injects
+`libatari800_debug_step_instruction()` into `src/libatari800/api.c` (and its
+declaration into `libatari800.h`) after configure, so it is immune to context
+drift in api.c and cannot clash with 0003. It:
+  - sets `MONITOR_break_step`, which stops `CPU_GO()` after one instruction and
+    makes the core skip the PC breakpoint table for that instruction -- exactly
+    the semantics needed to step off a breakpoint;
+  - passes `CPU_GO(ANTIC_xpos + 8)` so the limit is relative to the current
+    position in the scanline rather than a fixed value;
+  - arms the same `longjmp` landing pad `libatari800_next_frame()` uses, since
+    the stop arrives as `DO_BREAK -> ENTER_MONITOR -> Atari800_Exit()`, which in
+    libatari800 would otherwise terminate the process.
+
+`AtariEmulator::stepOneInstruction()` now calls it. Verified: PC advances one
+instruction per step ($2096 -> $2098 -> $209A -> $209C -> $209F, then JSR/RTS
+transfers), ~20 ms per step, and source-level stepping lands on the next source
+line instead of an arbitrary one.
+
+---
+
 ## 0019-libatari800-pc-breakpoints.patch (July 2026)
 
 **Problem:** Fujisan runs the CPU a whole frame at a time via

--- a/patches/CHANGES.md
+++ b/patches/CHANGES.md
@@ -55,6 +55,20 @@ no monitor in libatari800". A breakpoint would therefore terminate the process.
    `api.c` (declared in `libatari800.h`) populates `MONITOR_breakpoint_table[]`
    with PC-equals conditions so the CPU core halts every-instruction at a
    breakpoint. `count <= 0` disables all breakpoints.
+
+   Note the table is an AND/OR *expression* list, not a flat list of addresses:
+   `cpu.c` ANDs consecutive entries together, and an entry whose condition is
+   `MONITOR_BREAKPOINT_OR` separates alternatives (reaching one means the
+   preceding group matched, so the breakpoint fires). Writing N bare PC
+   conditions therefore means `PC == a AND PC == b`, which is never true, so
+   with two or more breakpoints set none of them fire. We emit a
+   `MONITOR_BREAKPOINT_OR` separator between addresses, which caps the usable
+   breakpoint count at `(MONITOR_BREAKPOINT_TABLE_MAX + 1) / 2`.
+
+   This was a real bug in the first version of this patch, and it hid well: a
+   breakpoint in a *hot loop* still appeared to work, because Fujisan's coarse
+   post-frame PC scan caught it by coincidence. Only one-shot addresses (a
+   specific source line) exposed it.
 2. `PLATFORM_Exit()` (`exit.c`) no longer terminates on a monitor break: when a
    break fires inside a frame it `longjmp`s back into `libatari800_next_frame()`
    (landing pad `libatari800_monitor_jmp`, guarded by `libatari800_monitor_active`),

--- a/scripts/configure-atari800.sh
+++ b/scripts/configure-atari800.sh
@@ -203,6 +203,55 @@ else
     # sees the correct PC. See patches/0019-libatari800-pc-breakpoints.patch.
     sed -i.bak 's|/\* #undef MONITOR_BREAK \*/|#define MONITOR_BREAK 1|' src/config.h
     sed -i.bak 's|/\* #undef MONITOR_BREAKPOINTS \*/|#define MONITOR_BREAKPOINTS 1|' src/config.h
+
+    # Provide a true single-instruction step entry point.
+    #
+    # Fujisan's stepOneInstruction() previously ran a whole frame, which breaks
+    # debugging: resuming from a breakpoint requires lifting that breakpoint and
+    # stepping one instruction off it, so a frame-sized "step" runs past every
+    # other breakpoint in that frame and they never fire again. The core skips
+    # the PC breakpoint table while MONITOR_break_step is set, which is exactly
+    # the semantics needed here.
+    #
+    # Injected here rather than as a diff so it is immune to context drift in
+    # api.c, and under its own name so it cannot clash with the
+    # libatari800_step_instruction() added by patches/0003.
+    if ! grep -q 'libatari800_debug_step_instruction' src/libatari800/api.c; then
+        cat >> src/libatari800/api.c <<'FUJISAN_STEP_EOF'
+
+/* Execute exactly one 6502 instruction (debugger single-step).
+ *
+ * MONITOR_break_step makes CPU_GO() stop after a single instruction, and the
+ * core skips the PC breakpoint table while it is set -- exactly what a debugger
+ * needs to step off a breakpoint. The stop arrives as DO_BREAK -> ENTER_MONITOR
+ * -> Atari800_Exit(), which in libatari800 would terminate the process, so arm
+ * the same longjmp landing pad libatari800_next_frame() uses (see
+ * PLATFORM_Exit() in exit.c) for the duration of the step. */
+void libatari800_debug_step_instruction(void)
+{
+#if defined(MONITOR_BREAK) && defined(HAVE_SETJMP)
+	if (setjmp(libatari800_monitor_jmp) == 0) {
+		libatari800_monitor_active = 1;
+		MONITOR_break_step = TRUE;
+		/* CPU_GO() runs while ANTIC_xpos < limit, so the limit must be
+		   relative to where we currently are in the scanline. A fixed
+		   limit (e.g. CPU_GO(20)) silently executes nothing whenever the
+		   CPU is already past that cycle, making the "step" a no-op.
+		   MONITOR_break_step stops us after one instruction regardless,
+		   so a small margin is enough. */
+		CPU_GO(ANTIC_xpos + 8);
+	}
+	libatari800_monitor_active = 0;
+	MONITOR_break_step = FALSE;
+#endif
+}
+FUJISAN_STEP_EOF
+        echo "injected libatari800_debug_step_instruction() into api.c"
+    fi
+    if ! grep -q 'libatari800_debug_step_instruction' src/libatari800/libatari800.h; then
+        sed -i.bak 's|#endif /\* LIBATARI800_H_ \*/|/* Execute exactly one 6502 instruction (debugger single-step). */\nvoid libatari800_debug_step_instruction(void);\n\n#endif /* LIBATARI800_H_ */|' src/libatari800/libatari800.h
+        echo "declared libatari800_debug_step_instruction() in libatari800.h"
+    fi
 fi
 
 echo "atari800 configuration completed"

--- a/src/atariemulator.cpp
+++ b/src/atariemulator.cpp
@@ -3474,15 +3474,23 @@ void AtariEmulator::stepOneFrame()
 void AtariEmulator::stepOneInstruction()
 {
     if (m_emulationPaused) {
-        // Without patches, we can't do true single-instruction stepping
-        // We'll use frame stepping as an approximation
-        // This executes many instructions but is the best we can do without patches
         unsigned short startPC = CPU_regPC;
-        
-        // Execute one frame
-        // This will execute thousands of instructions, but it's all we have
-        libatari800_next_frame(&m_currentInput);
-        
+
+        // True single-instruction step, via libatari800_step_instruction()
+        // (added by patches/0003-single-instruction-stepping.patch).
+        //
+        // This previously ran libatari800_next_frame(), i.e. thousands of
+        // instructions. That silently broke debuggers: to resume from a
+        // breakpoint a debugger must lift that breakpoint and step one
+        // instruction off it, so a "step" that executes a whole frame runs
+        // past every other breakpoint in that frame -- they never fire again
+        // for the rest of the session. It also made source-level stepping
+        // jump to essentially arbitrary lines.
+        //
+        // The core skips the PC breakpoint table while MONITOR_break_step is
+        // set, which is exactly the semantics needed to step off a breakpoint.
+        libatari800_debug_step_instruction();
+
         // Check breakpoints after execution
         checkBreakpoints();
 


### PR DESCRIPTION
This pull request introduces true single-instruction stepping to the Atari emulator, fixing longstanding issues with debugger integration and breakpoint handling. Previously, stepping executed an entire frame (thousands of instructions), making source-level debugging unreliable and causing breakpoints to be missed. Now, a new entry point ensures that only a single 6502 instruction is executed per step, which is essential for accurate debugging. The patch also corrects how multiple breakpoints are handled, ensuring they all work as expected.

**Single-instruction stepping improvements:**

* Added `libatari800_debug_step_instruction()` to the core, injected by `scripts/configure-atari800.sh`, which executes exactly one 6502 instruction and properly manages breakpoints and control flow using `MONITOR_break_step` and a `longjmp` landing pad. (`[scripts/configure-atari800.shR206-R254](diffhunk://#diff-2c08431e3389f086a8d09d210e06f747682e9f1c96ed41b53c596d5057317152R206-R254)`)
* Updated `AtariEmulator::stepOneInstruction()` to use the new single-step function instead of running an entire frame, fixing debugger stepping and source-level navigation. (`[src/atariemulator.cppL3477-R3492](diffhunk://#diff-4f8959777cff37e5ee170867c1c24b5892c7c8365a37bfa24ee97da8adef2b95L3477-R3492)`)
* Declared the new function in the public API header (`libatari800.h`). (`[include/atariemulator.hR139-R141](diffhunk://#diff-ebd939ea2bb80e8426f3ff7293ce93f6426ad0b2fbe57e1dcf539fcc1c338ad8R139-R141)`)

**Breakpoint handling fixes:**

* Fixed `libatari800_set_pc_breakpoints()` to correctly handle multiple breakpoints by emitting `MONITOR_BREAKPOINT_OR` separators, ensuring all breakpoints can fire as intended. This avoids a subtle bug where only one breakpoint would ever work. (`[patches/0019-libatari800-pc-breakpoints.patchL93-R132](diffhunk://#diff-9aa614fcc0ac4b2a9bd630cdcd0ca4f1b4f4bee2b369806ddf9807ae0789f425L93-R132)`)
* Documented the AND/OR breakpoint table semantics and the previous bug in `patches/CHANGES.md` for future reference. (`[patches/CHANGES.mdR58-R71](diffhunk://#diff-89ba6f323480e5d934484cf6b51103049f62b4c65ff7ff8cf0f9468123b00d1bR58-R71)`)

**Documentation:**

* Added a detailed changelog entry in `patches/CHANGES.md` explaining the problems with previous stepping and how the new implementation fixes them. (`[patches/CHANGES.mdR3-R40](diffhunk://#diff-89ba6f323480e5d934484cf6b51103049f62b4c65ff7ff8cf0f9468123b00d1bR3-R40)`)

These changes collectively make the emulator's debugging experience accurate and reliable, especially when interacting with breakpoints and stepping through code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added true single-instruction stepping for the emulator debugger.
  - Added PC breakpoint support, allowing execution to pause when specified program counters are reached.
  - Added breakpoint status reporting so integrations can detect when execution stopped at a breakpoint.

- **Bug Fixes**
  - Debugger stepping no longer runs an entire frame or skips over breakpoints.
  - Breakpoint hits return control to the host instead of terminating emulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->