### PR TITLE
Fix container build on Fedora

### DIFF
--- a/scripts/build-linux-docker.sh
+++ b/scripts/build-linux-docker.sh
@@ -187,7 +187,7 @@ echo_info "Building Ubuntu 22.04 based container for $ARCH..."
 $CONTAINER_RUNTIME build \
     --platform linux/$ARCH \
     -f docker/Dockerfile.ubuntu-22.04 \
-    -t fujisan-linux-builder:ubuntu22-$ARCH \
+    -t localhost/fujisan-linux-builder:ubuntu22-$ARCH \
     . || {
     echo_error "Failed to build container image"
     exit 1
@@ -951,8 +951,8 @@ echo_step "Building Fujisan in Container"
 echo_info "Running build for version $VERSION on $ARCH..."
 $CONTAINER_RUNTIME run --rm \
     --platform linux/$ARCH \
-    -v "$PROJECT_ROOT:/build/fujisan:ro" \
-    -v "$LINUX_BUILD_DIR:/output" \
+    -v "$PROJECT_ROOT:/build/fujisan:ro,z" \
+    -v "$LINUX_BUILD_DIR:/output:z" \
     ${FUJINET_VOLUME_ARG:+$FUJINET_VOLUME_ARG} \
     ${FASTBASIC_VOLUME_ARG:+$FASTBASIC_VOLUME_ARG} \
     -e VERSION="$VERSION" \
@@ -960,7 +960,7 @@ $CONTAINER_RUNTIME run --rm \
     -e ARCH="$ARCH" \
     -e BUILD_FUJINET_PC="$BUILD_FUJINET_PC" \
     -e BUILD_FASTBASIC_COMPILER="$BUILD_FASTBASIC_COMPILER" \
-    fujisan-linux-builder:ubuntu22-$ARCH \
+    localhost/fujisan-linux-builder:ubuntu22-$ARCH \
     bash /output/build-in-container.sh "$VERSION" "$VERSION_CLEAN" "$BUILD_DEB" "$BUILD_TARBALL" "$ARCH" || {
     echo_error "Build failed"
     exit 1
@@ -1001,7 +1001,7 @@ fi
 # Clean up container if not keeping
 if [[ "$KEEP_CONTAINER" == "false" ]]; then
     echo_info "Removing container image..."
-    $CONTAINER_RUNTIME rmi fujisan-linux-builder:ubuntu22-$ARCH 2>/dev/null || true
+    $CONTAINER_RUNTIME rmi localhost/fujisan-linux-builder:ubuntu22-$ARCH 2>/dev/null || true
 fi
 
 # Summary


### PR DESCRIPTION
When running "build.sh linux" on Fedora 44, got the error:

STEP 4/4: WORKDIR /build
COMMIT fujisan-linux-builder:ubuntu22-amd64
--> 1190941a8c41
Successfully tagged localhost/fujisan-linux-builder:ubuntu22-amd64
1190941a8c41c5d6230a01c26b7cf7dec78979c0126ba61167c8ac8cfd9c21a0
✓ Container image built
=== Building Fujisan in Container ===
→ Running build for version v1.0.0-dev on amd64...
✔ registry.fedoraproject.org/fujisan-linux-builder:ubuntu22-amd64
bash: /output/build-in-container.sh: Permission denied
ERROR: Build failed

This fail was due to SELinux (Security Enhanced Linux) being in enforcing mode, and the bind mounts just need the :z label to work with that.

The other problem was that Fedora short-name resolution goes against its registry list, so you can see it grabbed registry.fedoraproject.org/fujisan-linux-builder:ubuntu22-amd64 instead of the local newly-built image.

A few small edits got it running under Fedora 44 with SELinux enforcing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux container builds by ensuring locally tagged images are recognized consistently.
  * Added safer read-only access to source files and improved permissions for build output on SELinux-enabled systems.
  * Updated cleanup behavior to remove the correct local container image when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->