### PR TITLE
Fully customizable keyboard joystick mappings 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ set(SOURCES
     src/cassettewidget.cpp
     src/cartridgewidget.cpp
     src/joystickswapwidget.cpp
+    src/keycapturebutton.cpp
     src/volumeknob.cpp
     src/printerwidget.cpp
     src/mediaperipheralsdock.cpp
@@ -331,6 +332,8 @@ set(HEADERS
     include/cassettewidget.h
     include/cartridgewidget.h
     include/joystickswapwidget.h
+    include/keycapturebutton.h
+    include/keyboardjoystickmap.h
     include/volumeknob.h
     include/printerwidget.h
     include/mediaperipheralsdock.h

--- a/docs/KEYBOARD_SHORTCUTS.md
+++ b/docs/KEYBOARD_SHORTCUTS.md
@@ -42,15 +42,26 @@
 | | Shift+Del (⌦) | Delete Line |
 | | Shift+Backspace (Mac) | Delete Line (Mac alternative — maps physical delete key) |
 | | Shift+Home | Clear Screen |
-| **Joystick Controls** | | |
-| | Arrow Keys / Numpad 2,4,6,8 | Joystick Direction. Uncheck "Enable Joystick Support" in System > Settings > Input Configuration to use the arrow keys for text editing. |
-| | Numpad Enter | Joystick Fire |
-| | W,A,S,D | WASD Joystick Direction |
-| | Space | WASD Joystick Fire |
-| | Q,E,Z,C | WASD Joystick Diagonals |
+| **Joystick Controls** (defaults — fully customizable in System > Settings > Input Configuration) | | |
+| | Numpad 2,4,6,8 | Joystick 1 Direction (default) |
+| | Numpad Enter | Joystick 1 Fire (default) |
+| | W,A,S,D | Joystick 2 Direction (default) |
+| | Space | Joystick 2 Fire (default) |
+| | Q,E,Z,C | Joystick 2 Diagonals (default) |
 | **Special Functions** | | |
 | | Escape | Atari Escape |
 | | Caps Lock | Atari Caps Lock |
+
+## Customizing Joystick Keys
+
+Both keyboard joysticks are fully remappable in **System > Settings > Input Configuration**:
+for each joystick you can bind the fire button and all 8 Atari joystick directions
+(Up, Down, Left, Right and the 4 diagonals). Click a key button and press the desired key;
+Escape cancels. Diagonal bindings are optional — clear one with Backspace/Delete and the
+diagonal works by holding two direction keys. The Numpad / Arrows / WASD dropdowns act as
+layout templates; editing any key switches the layout to "Custom". Bindings are saved in
+the application settings and in configuration profiles. Numpad keys are distinguished from
+their main-keyboard equivalents (e.g. Numpad Enter vs Return).
 
 ## Notes
 

--- a/include/atariemulator.h
+++ b/include/atariemulator.h
@@ -26,6 +26,7 @@
 #include <QMutex>
 #include <QImage>
 #include <atomic>
+#include "keyboardjoystickmap.h"
 
 #ifdef HAVE_SDL2_AUDIO
 // Forward declaration to avoid including SDL headers here
@@ -288,11 +289,21 @@ public:
     QString getJoystick0Preset() const { return m_joystick0Preset; }
     QString getJoystick1Preset() const { return m_joystick1Preset; }
 
+    /// Set a custom keyboard map from an encoded string (see keyboardjoystickmap.h).
+    /// Malformed or empty strings are ignored. Marks the port's preset as "custom".
+    void setJoystick0KeyMap(const QString& encodedMap);
+    void setJoystick1KeyMap(const QString& encodedMap);
+    QString getJoystick0KeyMap() const { return KbdJoy::encodeMapToString(m_joystick0Map); }
+    QString getJoystick1KeyMap() const { return KbdJoy::encodeMapToString(m_joystick1Map); }
+
 public slots:
-    /// Apply joystick master flag, per-port devices, kbd-joy flags, swap, and presets (must run on emulator thread).
+    /// Apply joystick master flag, per-port devices, kbd-joy flags, swap, presets and
+    /// custom key maps (must run on emulator thread). Empty map strings derive the
+    /// map from the corresponding preset.
     void applyJoystickInputBundle(bool master, const QString& device1, const QString& device2,
                                   bool kbd0, bool kbd1, bool swap,
-                                  const QString& preset0, const QString& preset1);
+                                  const QString& preset0, const QString& preset1,
+                                  const QString& map0, const QString& map1);
 
 #ifdef HAVE_SDL2_JOYSTICK
     // Real joystick (SDL2) support
@@ -463,8 +474,21 @@ private:
     bool m_kbdJoy0Enabled = false;  // Default false - keyboard joysticks disabled by default
     bool m_kbdJoy1Enabled = false;  // Default false - keyboard joysticks disabled by default
     bool m_swapJoysticks = false;   // Default false: Joy0=Numpad, Joy1=WASD
-    QString m_joystick0Preset = "numpad";  // "numpad" | "arrows" | "wasd"
+    QString m_joystick0Preset = "numpad";  // "numpad" | "arrows" | "wasd" | "custom"
     QString m_joystick1Preset = "wasd";
+    KbdJoy::KeyboardJoystickMap m_joystick0Map = KbdJoy::KeyboardJoystickMap::numpadPreset();
+    KbdJoy::KeyboardJoystickMap m_joystick1Map = KbdJoy::KeyboardJoystickMap::wasdPreset();
+
+    /// Currently-held cardinal keys per keyboard joystick (diagonals are computed).
+    struct JoyKeyState {
+        bool up = false;
+        bool down = false;
+        bool left = false;
+        bool right = false;
+    };
+    JoyKeyState m_joy0KeyState;
+    JoyKeyState m_joy1KeyState;
+    bool m_kbdJoyStateInitialized = false;
     float m_targetFps = 59.92f;
     float m_frameTimeMs = 16.67f;
     input_template_t m_currentInput;

--- a/include/atariemulator.h
+++ b/include/atariemulator.h
@@ -293,7 +293,8 @@ public:
     QString getJoystick1Preset() const { return m_joystick1Preset; }
 
     /// Set a custom keyboard map from an encoded string (see keyboardjoystickmap.h).
-    /// Malformed or empty strings are ignored. Marks the port's preset as "custom".
+    /// Malformed or empty strings are ignored. Sets the port's preset name to the
+    /// matching built-in preset, or to "custom" when the map matches no preset.
     void setJoystick0KeyMap(const QString& encodedMap);
     void setJoystick1KeyMap(const QString& encodedMap);
     QString getJoystick0KeyMap() const { return KbdJoy::encodeMapToString(m_joystick0Map); }
@@ -492,6 +493,10 @@ private:
     JoyKeyState m_joy0KeyState;
     JoyKeyState m_joy1KeyState;
     bool m_kbdJoyStateInitialized = false;
+
+    /// Reset held-key state and centre stick / release fire for one port after its
+    /// mapping changed (caller must hold m_inputMutex). Swap-aware.
+    void resetJoystickPortStateLocked(int port);
     float m_targetFps = 59.92f;
     float m_frameTimeMs = 16.67f;
     input_template_t m_currentInput;

--- a/include/configurationprofile.h
+++ b/include/configurationprofile.h
@@ -98,6 +98,9 @@ struct ConfigurationProfile {
     QString joystick2Device;
     QString joystick1Preset = "numpad";
     QString joystick2Preset = "wasd";
+    /// Encoded custom keyboard maps (keyboardjoystickmap.h). Empty = derive from preset.
+    QString joystick1KeyMap;
+    QString joystick2KeyMap;
     bool swapJoysticks = false;
     bool grabMouse = false;
     QString mouseDevice;

--- a/include/joystickswapwidget.h
+++ b/include/joystickswapwidget.h
@@ -27,6 +27,10 @@ public:
     void setSwapped(bool swapped);
     void setCompactMode(bool compact);
 
+    /// Short key labels per logical joystick (up to 3 lines each: up, left/down/right, fire).
+    /// Empty strings fall back to the historical Numpad/WASD labels.
+    void setJoystickKeyLabels(const QStringList& joy1Lines, const QStringList& joy2Lines);
+
 signals:
     void toggled(bool swapped);
 
@@ -58,6 +62,8 @@ private:
     bool m_compactMode;
     int m_animationProgress; // 0-100
     QPropertyAnimation* m_animation;
+    QStringList m_joy1KeyLines;
+    QStringList m_joy2KeyLines;
     
     static const int WIDGET_HEIGHT = 80;
     static const int WIDGET_WIDTH = 320;

--- a/include/keyboardjoystickmap.h
+++ b/include/keyboardjoystickmap.h
@@ -1,0 +1,180 @@
+#ifndef KEYBOARDJOYSTICKMAP_H
+#define KEYBOARDJOYSTICKMAP_H
+
+#include <QString>
+#include <QStringList>
+#include <QKeySequence>
+#include <Qt>
+
+/// Shared definitions for customizable keyboard-joystick bindings.
+///
+/// A single binding is encoded as an int: the Qt::Key value with bit 30 set when the
+/// key is distinguished by Qt::KeypadModifier (numpad Enter/8 vs main Enter/8).
+/// 0 means "unbound" (only valid for the optional diagonal bindings).
+namespace KbdJoy {
+
+static const int KeypadFlag = 0x40000000;
+
+inline int encodeKey(int qtKey, bool keypad)
+{
+    if (qtKey == 0 || qtKey == Qt::Key_unknown) {
+        return 0;
+    }
+    return keypad ? (qtKey | KeypadFlag) : qtKey;
+}
+
+inline int decodeQtKey(int encoded)
+{
+    return encoded & ~KeypadFlag;
+}
+
+inline bool decodeKeypad(int encoded)
+{
+    return (encoded & KeypadFlag) != 0;
+}
+
+/// Per-joystick keyboard map: 4 cardinals + fire (required) and 4 diagonals
+/// (0 = unbound; diagonals then come from holding two cardinal keys).
+struct KeyboardJoystickMap {
+    int up = 0;
+    int down = 0;
+    int left = 0;
+    int right = 0;
+    int ul = 0;
+    int ur = 0;
+    int ll = 0;
+    int lr = 0;
+    int fire = 0;
+
+    bool operator==(const KeyboardJoystickMap& o) const
+    {
+        return up == o.up && down == o.down && left == o.left && right == o.right
+            && ul == o.ul && ur == o.ur && ll == o.ll && lr == o.lr && fire == o.fire;
+    }
+    bool operator!=(const KeyboardJoystickMap& o) const { return !(*this == o); }
+
+    static KeyboardJoystickMap numpadPreset()
+    {
+        KeyboardJoystickMap m;
+        m.up = encodeKey(Qt::Key_8, true);
+        m.down = encodeKey(Qt::Key_2, true);
+        m.left = encodeKey(Qt::Key_4, true);
+        m.right = encodeKey(Qt::Key_6, true);
+        m.fire = encodeKey(Qt::Key_Enter, true);
+        return m;
+    }
+
+    static KeyboardJoystickMap arrowsPreset()
+    {
+        KeyboardJoystickMap m;
+        m.up = encodeKey(Qt::Key_Up, false);
+        m.down = encodeKey(Qt::Key_Down, false);
+        m.left = encodeKey(Qt::Key_Left, false);
+        m.right = encodeKey(Qt::Key_Right, false);
+        m.fire = encodeKey(Qt::Key_Return, false);
+        return m;
+    }
+
+    static KeyboardJoystickMap wasdPreset()
+    {
+        KeyboardJoystickMap m;
+        m.up = encodeKey(Qt::Key_W, false);
+        m.down = encodeKey(Qt::Key_S, false);
+        m.left = encodeKey(Qt::Key_A, false);
+        m.right = encodeKey(Qt::Key_D, false);
+        m.ul = encodeKey(Qt::Key_Q, false);
+        m.ur = encodeKey(Qt::Key_E, false);
+        m.ll = encodeKey(Qt::Key_Z, false);
+        m.lr = encodeKey(Qt::Key_C, false);
+        m.fire = encodeKey(Qt::Key_Space, false);
+        return m;
+    }
+};
+
+inline bool isValidPresetName(const QString& preset)
+{
+    return preset == QStringLiteral("numpad")
+        || preset == QStringLiteral("arrows")
+        || preset == QStringLiteral("wasd");
+}
+
+/// Expand a preset name into its 9 bindings. Unknown names (including "custom")
+/// yield the numpad layout, matching the historical default for joystick 1.
+inline KeyboardJoystickMap mapForPreset(const QString& preset)
+{
+    if (preset == QStringLiteral("arrows")) {
+        return KeyboardJoystickMap::arrowsPreset();
+    }
+    if (preset == QStringLiteral("wasd")) {
+        return KeyboardJoystickMap::wasdPreset();
+    }
+    return KeyboardJoystickMap::numpadPreset();
+}
+
+/// Human-readable label for one binding, e.g. "W", "Space", "Enter (numpad)".
+inline QString keyDisplayName(int encoded)
+{
+    if (encoded == 0) {
+        return QStringLiteral("(none)");
+    }
+    QString name = QKeySequence(decodeQtKey(encoded)).toString();
+    if (name.isEmpty()) {
+        name = QStringLiteral("Key %1").arg(decodeQtKey(encoded));
+    }
+    if (decodeKeypad(encoded)) {
+        name += QStringLiteral(" (numpad)");
+    }
+    return name;
+}
+
+/// Serialize to a compact comma-separated string for QSettings / profile JSON.
+inline QString encodeMapToString(const KeyboardJoystickMap& m)
+{
+    return QStringLiteral("%1,%2,%3,%4,%5,%6,%7,%8,%9")
+        .arg(m.up).arg(m.down).arg(m.left).arg(m.right)
+        .arg(m.ul).arg(m.ur).arg(m.ll).arg(m.lr).arg(m.fire);
+}
+
+/// Parse a string produced by encodeMapToString(). Returns false if malformed.
+inline bool decodeMapFromString(const QString& s, KeyboardJoystickMap& out)
+{
+    const QStringList parts = s.split(QLatin1Char(','));
+    if (parts.size() != 9) {
+        return false;
+    }
+    int values[9];
+    for (int i = 0; i < 9; ++i) {
+        bool ok = false;
+        values[i] = parts[i].toInt(&ok);
+        if (!ok) {
+            return false;
+        }
+    }
+    // Fire and cardinals must be bound; diagonals may be 0.
+    if (values[0] == 0 || values[1] == 0 || values[2] == 0 || values[3] == 0 || values[8] == 0) {
+        return false;
+    }
+    out.up = values[0];
+    out.down = values[1];
+    out.left = values[2];
+    out.right = values[3];
+    out.ul = values[4];
+    out.ur = values[5];
+    out.ll = values[6];
+    out.lr = values[7];
+    out.fire = values[8];
+    return true;
+}
+
+/// Identify which preset a map matches, or "custom".
+inline QString presetNameForMap(const KeyboardJoystickMap& m)
+{
+    if (m == KeyboardJoystickMap::numpadPreset()) return QStringLiteral("numpad");
+    if (m == KeyboardJoystickMap::arrowsPreset()) return QStringLiteral("arrows");
+    if (m == KeyboardJoystickMap::wasdPreset()) return QStringLiteral("wasd");
+    return QStringLiteral("custom");
+}
+
+} // namespace KbdJoy
+
+#endif // KEYBOARDJOYSTICKMAP_H

--- a/include/keycapturebutton.h
+++ b/include/keycapturebutton.h
@@ -1,0 +1,46 @@
+#ifndef KEYCAPTUREBUTTON_H
+#define KEYCAPTUREBUTTON_H
+
+#include <QPushButton>
+#include <QPointer>
+
+/// Button that captures a single key press when clicked.
+///
+/// Click to arm ("Press a key…"), the next key press becomes the binding
+/// (encoded with KbdJoy::encodeKey, keeping the numpad distinction).
+/// Escape cancels; Backspace/Delete clears the binding if clearable.
+class KeyCaptureButton : public QPushButton
+{
+    Q_OBJECT
+
+public:
+    explicit KeyCaptureButton(QWidget* parent = nullptr);
+
+    void setEncodedKey(int encoded);
+    int encodedKey() const { return m_encoded; }
+
+    /// Allow clearing the binding (Backspace/Delete) — used for optional
+    /// diagonal bindings. Required bindings ignore clear requests.
+    void setClearable(bool clearable) { m_clearable = clearable; }
+
+signals:
+    void keyCaptured(int encoded);
+
+protected:
+    void keyPressEvent(QKeyEvent* event) override;
+    void focusOutEvent(QFocusEvent* event) override;
+
+private:
+    void beginCapture();
+    void endCapture();
+    void updateLabel();
+
+    bool m_capturing = false;
+    bool m_clearable = false;
+    int m_encoded = 0;
+
+    // Only one button captures at a time (the keyboard grab is exclusive).
+    static QPointer<KeyCaptureButton> s_activeCapture;
+};
+
+#endif // KEYCAPTUREBUTTON_H

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -157,6 +157,7 @@ private:
     void updateToolbarFromSettings();
     /// Read input/joystick* from QSettings and apply via AtariEmulator::applyJoystickInputBundle (worker thread).
     void syncEmulatorJoystickFromQSettings();
+    void updateKbdJoyKeyLabels();
     void updateBasicToggleState();
     void updateToolbarLogo();
     void updateToolbarButtonStyles();

--- a/include/settingsdialog.h
+++ b/include/settingsdialog.h
@@ -28,11 +28,13 @@
 #include "atariemulator.h"
 #include "configurationprofilemanager.h"
 #include "profileselectionwidget.h"
+#include "keyboardjoystickmap.h"
 
 // FujiNet support (NetSIO on Windows when atari800 built with 0010-netsio-windows-support.patch)
 class FujiNetService;
 class FujiNetProcessManager;
 class FujiNetBinaryManager;
+class KeyCaptureButton;
 
 class SettingsDialog : public QDialog
 {
@@ -113,6 +115,13 @@ private:
     void populateCartridgeTypes(QComboBox* combo);
     void populateJoystickDevices();
     void updateKeyboardMappingLabels();
+
+    // Keyboard joystick key-binding helpers (joy = 1 or 2).
+    QWidget* createKeyBindingGrid(int joy);
+    KbdJoy::KeyboardJoystickMap currentJoyMap(int joy) const;
+    void setJoyMapButtons(int joy, const KbdJoy::KeyboardJoystickMap& map);
+    void onKeyBindingCaptured(int joy);
+    void updateKeyConflictWarning();
     
     // Profile management
     ConfigurationProfile getCurrentUIState() const;
@@ -261,9 +270,13 @@ private:
     QComboBox* m_joystick2Preset;
     QCheckBox* m_swapJoysticks;
 
-    // Keyboard mapping labels (shown when "Keyboard" is selected)
-    QLabel* m_joystick1KeysLabel;
-    QLabel* m_joystick2KeysLabel;
+    // Per-joystick key binding grids (shown when device is "Keyboard").
+    // Button index order: 0=up, 1=down, 2=left, 3=right, 4=ul, 5=ur, 6=ll, 7=lr, 8=fire.
+    QWidget* m_joystick1KeysWidget = nullptr;
+    QWidget* m_joystick2KeysWidget = nullptr;
+    KeyCaptureButton* m_joy1KeyButtons[9] = {};
+    KeyCaptureButton* m_joy2KeyButtons[9] = {};
+    QLabel* m_keyConflictLabel = nullptr;
 
     // Mouse Configuration (hidden for future re-implementation)
     QGroupBox* m_mouseGroup;

--- a/src/atariemulator.cpp
+++ b/src/atariemulator.cpp
@@ -2815,21 +2815,42 @@ void AtariEmulator::setKbdJoy1Enabled(bool enabled)
 #endif
 }
 
+void AtariEmulator::resetJoystickPortStateLocked(int port)
+{
+    // Port 0's map/state drives logical joy1 when joysticks are swapped
+    // (mirrors the mapping in handleJoystickKeyboardEmulation).
+    const int INPUT_STICK_CENTRE = 0x0f ^ 0xff;
+    const bool drivesLogical1 = (m_swapJoysticks == (port == 0));
+
+    JoyKeyState& st = (port == 0) ? m_joy0KeyState : m_joy1KeyState;
+    st = JoyKeyState();
+
+    if (drivesLogical1) {
+        m_currentInput.joy1 = INPUT_STICK_CENTRE;
+        m_currentInput.trig1 = 0;
+    } else {
+        m_currentInput.joy0 = INPUT_STICK_CENTRE;
+        m_currentInput.trig0 = 0;
+    }
+}
+
 void AtariEmulator::setJoystick0Preset(const QString& preset)
 {
     if (KbdJoy::isValidPresetName(preset)) {
+        QMutexLocker inputLock(&m_inputMutex);
         m_joystick0Preset = preset;
         m_joystick0Map = KbdJoy::mapForPreset(preset);
-        m_joy0KeyState = JoyKeyState();
+        resetJoystickPortStateLocked(0);
     }
 }
 
 void AtariEmulator::setJoystick1Preset(const QString& preset)
 {
     if (KbdJoy::isValidPresetName(preset)) {
+        QMutexLocker inputLock(&m_inputMutex);
         m_joystick1Preset = preset;
         m_joystick1Map = KbdJoy::mapForPreset(preset);
-        m_joy1KeyState = JoyKeyState();
+        resetJoystickPortStateLocked(1);
     }
 }
 
@@ -2837,9 +2858,10 @@ void AtariEmulator::setJoystick0KeyMap(const QString& encodedMap)
 {
     KbdJoy::KeyboardJoystickMap map;
     if (KbdJoy::decodeMapFromString(encodedMap, map)) {
+        QMutexLocker inputLock(&m_inputMutex);
         m_joystick0Map = map;
         m_joystick0Preset = KbdJoy::presetNameForMap(map);
-        m_joy0KeyState = JoyKeyState();
+        resetJoystickPortStateLocked(0);
     }
 }
 
@@ -2847,9 +2869,10 @@ void AtariEmulator::setJoystick1KeyMap(const QString& encodedMap)
 {
     KbdJoy::KeyboardJoystickMap map;
     if (KbdJoy::decodeMapFromString(encodedMap, map)) {
+        QMutexLocker inputLock(&m_inputMutex);
         m_joystick1Map = map;
         m_joystick1Preset = KbdJoy::presetNameForMap(map);
-        m_joy1KeyState = JoyKeyState();
+        resetJoystickPortStateLocked(1);
     }
 }
 

--- a/src/atariemulator.cpp
+++ b/src/atariemulator.cpp
@@ -2817,15 +2817,39 @@ void AtariEmulator::setKbdJoy1Enabled(bool enabled)
 
 void AtariEmulator::setJoystick0Preset(const QString& preset)
 {
-    if (preset == "numpad" || preset == "arrows" || preset == "wasd") {
+    if (KbdJoy::isValidPresetName(preset)) {
         m_joystick0Preset = preset;
+        m_joystick0Map = KbdJoy::mapForPreset(preset);
+        m_joy0KeyState = JoyKeyState();
     }
 }
 
 void AtariEmulator::setJoystick1Preset(const QString& preset)
 {
-    if (preset == "numpad" || preset == "arrows" || preset == "wasd") {
+    if (KbdJoy::isValidPresetName(preset)) {
         m_joystick1Preset = preset;
+        m_joystick1Map = KbdJoy::mapForPreset(preset);
+        m_joy1KeyState = JoyKeyState();
+    }
+}
+
+void AtariEmulator::setJoystick0KeyMap(const QString& encodedMap)
+{
+    KbdJoy::KeyboardJoystickMap map;
+    if (KbdJoy::decodeMapFromString(encodedMap, map)) {
+        m_joystick0Map = map;
+        m_joystick0Preset = KbdJoy::presetNameForMap(map);
+        m_joy0KeyState = JoyKeyState();
+    }
+}
+
+void AtariEmulator::setJoystick1KeyMap(const QString& encodedMap)
+{
+    KbdJoy::KeyboardJoystickMap map;
+    if (KbdJoy::decodeMapFromString(encodedMap, map)) {
+        m_joystick1Map = map;
+        m_joystick1Preset = KbdJoy::presetNameForMap(map);
+        m_joy1KeyState = JoyKeyState();
     }
 }
 
@@ -3651,10 +3675,13 @@ bool AtariEmulator::handleJoystickKeyboardEmulation(QKeyEvent* event)
         return false;
     }
 
-    int key = event->key();
-    Qt::KeyboardModifiers modifiers = event->modifiers();
-    bool isKeyPress = (event->type() == QEvent::KeyPress);
-    
+    const int encodedKey = KbdJoy::encodeKey(event->key(),
+                                             (event->modifiers() & Qt::KeypadModifier) != 0);
+    if (encodedKey == 0) {
+        return false;
+    }
+    const bool isKeyPress = (event->type() == QEvent::KeyPress);
+
     // Joystick key event processing
     // libatari800 XORs joystick values with 0xff, so we need to send inverted values
     // Original INPUT_STICK_* constants XORed with 0xff:
@@ -3667,195 +3694,60 @@ bool AtariEmulator::handleJoystickKeyboardEmulation(QKeyEvent* event)
     const int INPUT_STICK_UR = 0x06 ^ 0xff;       // Up+Right: 0x06 -> 0xf9
     const int INPUT_STICK_LL = 0x09 ^ 0xff;       // Down+Left: 0x09 -> 0xf6
     const int INPUT_STICK_LR = 0x05 ^ 0xff;       // Down+Right: 0x05 -> 0xfa
-    
-    // Track currently pressed directional keys for each joystick
-    static bool joy0_up = false, joy0_down = false, joy0_left = false, joy0_right = false;
-    static bool joy1_up = false, joy1_down = false, joy1_left = false, joy1_right = false;
-    static bool trig0State = false;
-    static bool trig1State = false;
-    static bool initialized = false;
-    
-    // Initialize trigger states on first call
-    if (!initialized) {
+
+    // Initialize trigger/stick states on first call
+    if (!m_kbdJoyStateInitialized) {
         m_currentInput.trig0 = 0;
         m_currentInput.trig1 = 0;
         m_currentInput.joy0 = INPUT_STICK_CENTRE;
         m_currentInput.joy1 = INPUT_STICK_CENTRE;
-        initialized = true;
+        m_kbdJoyStateInitialized = true;
     }
-    
-    // Effective presets per logical joystick (swap applies device+preset assignment)
-    QString joy0Preset = m_swapJoysticks ? m_joystick1Preset : m_joystick0Preset;
-    QString joy1Preset = m_swapJoysticks ? m_joystick0Preset : m_joystick1Preset;
-    
+
     // Helper to calculate joystick position from directional key states
-    auto calculateJoystickValue = [&](bool up, bool down, bool left, bool right) -> int {
-        if (up && left) return INPUT_STICK_UL;
-        if (up && right) return INPUT_STICK_UR;
-        if (down && left) return INPUT_STICK_LL;
-        if (down && right) return INPUT_STICK_LR;
-        if (up) return INPUT_STICK_FORWARD;
-        if (down) return INPUT_STICK_BACK;
-        if (left) return INPUT_STICK_LEFT;
-        if (right) return INPUT_STICK_RIGHT;
+    auto calculateJoystickValue = [&](const JoyKeyState& st) -> int {
+        if (st.up && st.left) return INPUT_STICK_UL;
+        if (st.up && st.right) return INPUT_STICK_UR;
+        if (st.down && st.left) return INPUT_STICK_LL;
+        if (st.down && st.right) return INPUT_STICK_LR;
+        if (st.up) return INPUT_STICK_FORWARD;
+        if (st.down) return INPUT_STICK_BACK;
+        if (st.left) return INPUT_STICK_LEFT;
+        if (st.right) return INPUT_STICK_RIGHT;
         return INPUT_STICK_CENTRE;
     };
 
-    // --- Arrows preset: arrow keys only + Return (before numpad so arrow keys are not captured by numpad-only ports) ---
-    bool arrowsJoy0 = m_kbdJoy0Enabled && joy0Preset == "arrows";
-    bool arrowsJoy1 = m_kbdJoy1Enabled && joy1Preset == "arrows";
-    if (arrowsJoy0 || arrowsJoy1) {
-        switch (key) {
-            case Qt::Key_Up:
-                if (arrowsJoy0) { joy0_up = isKeyPress; m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right); }
-                if (arrowsJoy1) { joy1_up = isKeyPress; m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right); }
-                return true;
-            case Qt::Key_Down:
-                if (arrowsJoy0) { joy0_down = isKeyPress; m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right); }
-                if (arrowsJoy1) { joy1_down = isKeyPress; m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right); }
-                return true;
-            case Qt::Key_Left:
-                if (arrowsJoy0) { joy0_left = isKeyPress; m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right); }
-                if (arrowsJoy1) { joy1_left = isKeyPress; m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right); }
-                return true;
-            case Qt::Key_Right:
-                if (arrowsJoy0) { joy0_right = isKeyPress; m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right); }
-                if (arrowsJoy1) { joy1_right = isKeyPress; m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right); }
-                return true;
-        }
-        // Trigger: Return (main Enter, not Numpad Enter)
-        if (key == Qt::Key_Return && !(modifiers & Qt::KeypadModifier)) {
-            if (arrowsJoy0) { trig0State = isKeyPress; m_currentInput.trig0 = isKeyPress ? 1 : 0; }
-            if (arrowsJoy1) { trig1State = isKeyPress; m_currentInput.trig1 = isKeyPress ? 1 : 0; }
-            return true;
-        }
+    // Apply one key event to one joystick's map. Diagonal keys (when bound) force the
+    // diagonal stick value while held and fall back to the cardinal state on release.
+    auto applyToJoystick = [&](const KbdJoy::KeyboardJoystickMap& map, JoyKeyState& st,
+                               UBYTE& joy, UBYTE& trig) -> bool {
+        if (encodedKey == map.up)    { st.up = isKeyPress;    joy = calculateJoystickValue(st); return true; }
+        if (encodedKey == map.down)  { st.down = isKeyPress;  joy = calculateJoystickValue(st); return true; }
+        if (encodedKey == map.left)  { st.left = isKeyPress;  joy = calculateJoystickValue(st); return true; }
+        if (encodedKey == map.right) { st.right = isKeyPress; joy = calculateJoystickValue(st); return true; }
+        if (encodedKey == map.fire)  { trig = isKeyPress ? 1 : 0; return true; }
+        if (map.ul != 0 && encodedKey == map.ul) { joy = isKeyPress ? INPUT_STICK_UL : calculateJoystickValue(st); return true; }
+        if (map.ur != 0 && encodedKey == map.ur) { joy = isKeyPress ? INPUT_STICK_UR : calculateJoystickValue(st); return true; }
+        if (map.ll != 0 && encodedKey == map.ll) { joy = isKeyPress ? INPUT_STICK_LL : calculateJoystickValue(st); return true; }
+        if (map.lr != 0 && encodedKey == map.lr) { joy = isKeyPress ? INPUT_STICK_LR : calculateJoystickValue(st); return true; }
+        return false;
+    };
+
+    // Effective maps per logical joystick (swap applies device+map assignment)
+    const KbdJoy::KeyboardJoystickMap& joy0Map = m_swapJoysticks ? m_joystick1Map : m_joystick0Map;
+    const KbdJoy::KeyboardJoystickMap& joy1Map = m_swapJoysticks ? m_joystick0Map : m_joystick1Map;
+    JoyKeyState& joy0State = m_swapJoysticks ? m_joy1KeyState : m_joy0KeyState;
+    JoyKeyState& joy1State = m_swapJoysticks ? m_joy0KeyState : m_joy1KeyState;
+
+    bool handled = false;
+    if (m_kbdJoy0Enabled) {
+        handled |= applyToJoystick(joy0Map, joy0State, m_currentInput.joy0, m_currentInput.trig0);
+    }
+    if (m_kbdJoy1Enabled) {
+        handled |= applyToJoystick(joy1Map, joy1State, m_currentInput.joy1, m_currentInput.trig1);
     }
 
-    // --- Numpad preset: 8/2/4/6 or arrows + Numpad Enter ---
-    bool numpadJoy0 = m_kbdJoy0Enabled && joy0Preset == "numpad";
-    bool numpadJoy1 = m_kbdJoy1Enabled && joy1Preset == "numpad";
-    if (numpadJoy0 || numpadJoy1) {
-        bool isNumpadDir = (modifiers & Qt::KeypadModifier) || key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Left || key == Qt::Key_Right;
-        bool arrowKey = (key == Qt::Key_Up || key == Qt::Key_Down || key == Qt::Key_Left || key == Qt::Key_Right);
-        bool numpadKey = (key == Qt::Key_8 || key == Qt::Key_2 || key == Qt::Key_4 || key == Qt::Key_6) && (modifiers & Qt::KeypadModifier);
-
-        if (isNumpadDir && (numpadKey || arrowKey)) {
-            switch (key) {
-                case Qt::Key_8:
-                case Qt::Key_Up: {
-                    bool handled = false;
-                    if (numpadJoy0 && (arrowKey || (key == Qt::Key_8 && (modifiers & Qt::KeypadModifier)))) {
-                        joy0_up = isKeyPress;
-                        m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right);
-                        handled = true;
-                    }
-                    if (numpadJoy1 && (arrowKey || (key == Qt::Key_8 && (modifiers & Qt::KeypadModifier)))) {
-                        joy1_up = isKeyPress;
-                        m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right);
-                        handled = true;
-                    }
-                    return handled;
-                }
-                case Qt::Key_2:
-                case Qt::Key_Down: {
-                    bool handled = false;
-                    if (numpadJoy0 && (arrowKey || (key == Qt::Key_2 && (modifiers & Qt::KeypadModifier)))) {
-                        joy0_down = isKeyPress;
-                        m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right);
-                        handled = true;
-                    }
-                    if (numpadJoy1 && (arrowKey || (key == Qt::Key_2 && (modifiers & Qt::KeypadModifier)))) {
-                        joy1_down = isKeyPress;
-                        m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right);
-                        handled = true;
-                    }
-                    return handled;
-                }
-                case Qt::Key_4:
-                case Qt::Key_Left: {
-                    bool handled = false;
-                    if (numpadJoy0 && (arrowKey || (key == Qt::Key_4 && (modifiers & Qt::KeypadModifier)))) {
-                        joy0_left = isKeyPress;
-                        m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right);
-                        handled = true;
-                    }
-                    if (numpadJoy1 && (arrowKey || (key == Qt::Key_4 && (modifiers & Qt::KeypadModifier)))) {
-                        joy1_left = isKeyPress;
-                        m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right);
-                        handled = true;
-                    }
-                    return handled;
-                }
-                case Qt::Key_6:
-                case Qt::Key_Right: {
-                    bool handled = false;
-                    if (numpadJoy0 && (arrowKey || (key == Qt::Key_6 && (modifiers & Qt::KeypadModifier)))) {
-                        joy0_right = isKeyPress;
-                        m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right);
-                        handled = true;
-                    }
-                    if (numpadJoy1 && (arrowKey || (key == Qt::Key_6 && (modifiers & Qt::KeypadModifier)))) {
-                        joy1_right = isKeyPress;
-                        m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right);
-                        handled = true;
-                    }
-                    return handled;
-                }
-            }
-        }
-        // Trigger: Numpad Enter only
-        if (key == Qt::Key_Enter && (modifiers & Qt::KeypadModifier)) {
-            if (numpadJoy0) { trig0State = isKeyPress; m_currentInput.trig0 = isKeyPress ? 1 : 0; }
-            if (numpadJoy1) { trig1State = isKeyPress; m_currentInput.trig1 = isKeyPress ? 1 : 0; }
-            return true;
-        }
-    }
-
-    // --- WASD preset: W/A/S/D + Space ---
-    bool wasdJoy0 = m_kbdJoy0Enabled && joy0Preset == "wasd";
-    bool wasdJoy1 = m_kbdJoy1Enabled && joy1Preset == "wasd";
-    if (wasdJoy0 || wasdJoy1) {
-        switch (key) {
-            case Qt::Key_W:
-                if (wasdJoy0) { joy0_up = isKeyPress; m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right); }
-                if (wasdJoy1) { joy1_up = isKeyPress; m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right); }
-                return true;
-            case Qt::Key_S:
-                if (wasdJoy0) { joy0_down = isKeyPress; m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right); }
-                if (wasdJoy1) { joy1_down = isKeyPress; m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right); }
-                return true;
-            case Qt::Key_A:
-                if (wasdJoy0) { joy0_left = isKeyPress; m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right); }
-                if (wasdJoy1) { joy1_left = isKeyPress; m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right); }
-                return true;
-            case Qt::Key_D:
-                if (wasdJoy0) { joy0_right = isKeyPress; m_currentInput.joy0 = calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right); }
-                if (wasdJoy1) { joy1_right = isKeyPress; m_currentInput.joy1 = calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right); }
-                return true;
-            case Qt::Key_Space:
-                if (wasdJoy0) { trig0State = isKeyPress; m_currentInput.trig0 = isKeyPress ? 1 : 0; }
-                if (wasdJoy1) { trig1State = isKeyPress; m_currentInput.trig1 = isKeyPress ? 1 : 0; }
-                return true;
-            case Qt::Key_Q:
-                if (wasdJoy0) m_currentInput.joy0 = isKeyPress ? INPUT_STICK_UL : calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right);
-                if (wasdJoy1) m_currentInput.joy1 = isKeyPress ? INPUT_STICK_UL : calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right);
-                return true;
-            case Qt::Key_E:
-                if (wasdJoy0) m_currentInput.joy0 = isKeyPress ? INPUT_STICK_UR : calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right);
-                if (wasdJoy1) m_currentInput.joy1 = isKeyPress ? INPUT_STICK_UR : calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right);
-                return true;
-            case Qt::Key_Z:
-                if (wasdJoy0) m_currentInput.joy0 = isKeyPress ? INPUT_STICK_LL : calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right);
-                if (wasdJoy1) m_currentInput.joy1 = isKeyPress ? INPUT_STICK_LL : calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right);
-                return true;
-            case Qt::Key_C:
-                if (wasdJoy0) m_currentInput.joy0 = isKeyPress ? INPUT_STICK_LR : calculateJoystickValue(joy0_up, joy0_down, joy0_left, joy0_right);
-                if (wasdJoy1) m_currentInput.joy1 = isKeyPress ? INPUT_STICK_LR : calculateJoystickValue(joy1_up, joy1_down, joy1_left, joy1_right);
-                return true;
-        }
-    }
-    
-    return false;
+    return handled;
 }
 
 // SIO patch control functions for disk speed investigation
@@ -4015,6 +3907,14 @@ QJsonObject AtariEmulator::getAllJoystickStates() const
         }
     };
     
+    // Human-readable summary of a keyboard map for status reporting
+    auto keyMapSummary = [](const KbdJoy::KeyboardJoystickMap& m) -> QString {
+        return QStringLiteral("%1/%2/%3/%4 Fire:%5")
+            .arg(KbdJoy::keyDisplayName(m.up), KbdJoy::keyDisplayName(m.down),
+                 KbdJoy::keyDisplayName(m.left), KbdJoy::keyDisplayName(m.right),
+                 KbdJoy::keyDisplayName(m.fire));
+    };
+
     // Joystick 1
     QJsonObject joy1;
     joy1["direction"] = getDirectionName(m_currentInput.joy0);
@@ -4022,7 +3922,8 @@ QJsonObject AtariEmulator::getAllJoystickStates() const
     joy1["fire"] = (m_currentInput.trig0 == 1);  // 1 = pressed in our inverted logic
     joy1["keyboard_enabled"] = m_kbdJoy0Enabled;
     joy1["keyboard_keys"] = m_swapJoysticks ? m_joystick1Preset : m_joystick0Preset;
-    
+    joy1["keyboard_map"] = keyMapSummary(m_swapJoysticks ? m_joystick1Map : m_joystick0Map);
+
     // Joystick 2
     QJsonObject joy2;
     joy2["direction"] = getDirectionName(m_currentInput.joy1);
@@ -4030,6 +3931,7 @@ QJsonObject AtariEmulator::getAllJoystickStates() const
     joy2["fire"] = (m_currentInput.trig1 == 1);  // 1 = pressed in our inverted logic
     joy2["keyboard_enabled"] = m_kbdJoy1Enabled;
     joy2["keyboard_keys"] = m_swapJoysticks ? m_joystick0Preset : m_joystick1Preset;
+    joy2["keyboard_map"] = keyMapSummary(m_swapJoysticks ? m_joystick0Map : m_joystick1Map);
     
     result["joystick1"] = joy1;
     result["joystick2"] = joy2;
@@ -4280,12 +4182,20 @@ void AtariEmulator::checkBreakpoints()
 
 void AtariEmulator::applyJoystickInputBundle(bool master, const QString& device1, const QString& device2,
                                             bool kbd0, bool kbd1, bool swap,
-                                            const QString& preset0, const QString& preset1)
+                                            const QString& preset0, const QString& preset1,
+                                            const QString& map0, const QString& map1)
 {
     m_joystickInputEnabled.store(master);
     setJoysticksSwapped(swap);
     setJoystick0Preset(preset0);
     setJoystick1Preset(preset1);
+    // Custom maps (when provided) override the preset-derived maps.
+    if (!map0.isEmpty()) {
+        setJoystick0KeyMap(map0);
+    }
+    if (!map1.isEmpty()) {
+        setJoystick1KeyMap(map1);
+    }
     setKbdJoy0Enabled(kbd0);
     setKbdJoy1Enabled(kbd1);
 #ifdef HAVE_SDL2_JOYSTICK

--- a/src/configurationprofile.cpp
+++ b/src/configurationprofile.cpp
@@ -112,6 +112,8 @@ QJsonObject ConfigurationProfile::toJson() const {
     inputConfig["joystick2Device"] = joystick2Device;
     inputConfig["joystick1Preset"] = joystick1Preset;
     inputConfig["joystick2Preset"] = joystick2Preset;
+    inputConfig["joystick1KeyMap"] = joystick1KeyMap;
+    inputConfig["joystick2KeyMap"] = joystick2KeyMap;
     inputConfig["swapJoysticks"] = swapJoysticks;
     inputConfig["grabMouse"] = grabMouse;
     inputConfig["mouseDevice"] = mouseDevice;
@@ -305,6 +307,8 @@ void ConfigurationProfile::fromJson(const QJsonObject& json) {
         joystick2Device = inputConfig["joystick2Device"].toString();
         joystick1Preset = inputConfig["joystick1Preset"].toString("numpad");
         joystick2Preset = inputConfig["joystick2Preset"].toString("wasd");
+        joystick1KeyMap = inputConfig["joystick1KeyMap"].toString();
+        joystick2KeyMap = inputConfig["joystick2KeyMap"].toString();
         swapJoysticks = inputConfig["swapJoysticks"].toBool(false);
         grabMouse = inputConfig["grabMouse"].toBool(false);
         mouseDevice = inputConfig["mouseDevice"].toString();

--- a/src/joystickswapwidget.cpp
+++ b/src/joystickswapwidget.cpp
@@ -59,30 +59,44 @@ void JoystickSwapWidget::setCompactMode(bool compact)
     }
 }
 
+void JoystickSwapWidget::setJoystickKeyLabels(const QStringList& joy1Lines, const QStringList& joy2Lines)
+{
+    m_joy1KeyLines = joy1Lines;
+    m_joy2KeyLines = joy2Lines;
+    updateTooltip();
+    update();
+}
+
 void JoystickSwapWidget::updateTooltip()
 {
+    // Historical defaults when no custom labels were provided
+    const QStringList joy1 = m_joy1KeyLines.isEmpty()
+        ? QStringList{"↑", "←↓→", "Enter"} : m_joy1KeyLines;
+    const QStringList joy2 = m_joy2KeyLines.isEmpty()
+        ? QStringList{"W", "ASD", "Space"} : m_joy2KeyLines;
+    const QString j1Text = joy1.join(' ');
+    const QString j2Text = joy2.join(' ');
+
     if (m_compactMode) {
         QString tooltip = QString("Click to swap joystick assignments\n\n");
         if (!m_swapped) {
             tooltip += "Current (Normal):\n";
-            tooltip += "• J1 (Player 1): Numpad/Arrows (↑←↓→, Enter)\n";
-            tooltip += "• J2 (Player 2): WASD (WASD, Space)\n\n";
+            tooltip += QString("• J1 (Player 1): %1\n").arg(j1Text);
+            tooltip += QString("• J2 (Player 2): %1\n\n").arg(j2Text);
             tooltip += "Click to swap to:\n";
-            tooltip += "• J1 (Player 1): WASD (WASD, Space)\n";
-            tooltip += "• J2 (Player 2): Numpad/Arrows (↑←↓→, Enter)";
+            tooltip += QString("• J1 (Player 1): %1\n").arg(j2Text);
+            tooltip += QString("• J2 (Player 2): %1").arg(j1Text);
         } else {
             tooltip += "Current (Swapped):\n";
-            tooltip += "• J1 (Player 1): WASD (WASD, Space)\n";
-            tooltip += "• J2 (Player 2): Numpad/Arrows (↑←↓→, Enter)\n\n";
+            tooltip += QString("• J1 (Player 1): %1\n").arg(j2Text);
+            tooltip += QString("• J2 (Player 2): %1\n\n").arg(j1Text);
             tooltip += "Click to swap to:\n";
-            tooltip += "• J1 (Player 1): Numpad/Arrows (↑←↓→, Enter)\n";
-            tooltip += "• J2 (Player 2): WASD (WASD, Space)";
+            tooltip += QString("• J1 (Player 1): %1\n").arg(j1Text);
+            tooltip += QString("• J2 (Player 2): %1").arg(j2Text);
         }
         setToolTip(tooltip);
     } else {
-        setToolTip("Click to swap joystick assignments\n"
-                   "Default: WASD→J2, Numpad→J1\n"
-                   "Swapped: WASD→J1, Numpad→J2");
+        setToolTip("Click to swap joystick assignments");
     }
 }
 
@@ -142,12 +156,16 @@ void JoystickSwapWidget::paintEvent(QPaintEvent *event)
     }
     
     // Draw joystick boxes
+    const QStringList joy1Lines = m_joy1KeyLines.isEmpty()
+        ? QStringList{"↑", "←↓→", "Enter"} : m_joy1KeyLines;
+    const QStringList joy2Lines = m_joy2KeyLines.isEmpty()
+        ? QStringList{"W", "ASD", "Space"} : m_joy2KeyLines;
     if (!m_swapped) {
-        drawJoystickBox(painter, leftBox, "Player 1", {"↑", "←↓→", "Enter"}, true, true);
-        drawJoystickBox(painter, rightBox, "Player 2", {"W", "ASD", "Space"}, true, false);
+        drawJoystickBox(painter, leftBox, "Player 1", joy1Lines, true, true);
+        drawJoystickBox(painter, rightBox, "Player 2", joy2Lines, true, false);
     } else {
-        drawJoystickBox(painter, leftBox, "Player 1", {"W", "ASD", "Space"}, true, true);
-        drawJoystickBox(painter, rightBox, "Player 2", {"↑", "←↓→", "Enter"}, true, false);
+        drawJoystickBox(painter, leftBox, "Player 1", joy2Lines, true, true);
+        drawJoystickBox(painter, rightBox, "Player 2", joy1Lines, true, false);
     }
     
     // Draw swap arrows

--- a/src/keycapturebutton.cpp
+++ b/src/keycapturebutton.cpp
@@ -1,0 +1,105 @@
+#include "keycapturebutton.h"
+
+#include <QKeyEvent>
+#include <QFocusEvent>
+
+#include "keyboardjoystickmap.h"
+
+QPointer<KeyCaptureButton> KeyCaptureButton::s_activeCapture = nullptr;
+
+KeyCaptureButton::KeyCaptureButton(QWidget* parent)
+    : QPushButton(parent)
+{
+    setMinimumWidth(120);
+    // macOS gives push buttons tab-only focus by default; we need keyboard focus
+    // on click so the armed button actually receives the keystroke.
+    setFocusPolicy(Qt::StrongFocus);
+    connect(this, &QPushButton::clicked, this, &KeyCaptureButton::beginCapture);
+    updateLabel();
+}
+
+void KeyCaptureButton::setEncodedKey(int encoded)
+{
+    m_encoded = encoded;
+    updateLabel();
+}
+
+void KeyCaptureButton::beginCapture()
+{
+    // Disarm any other button that is still capturing (the grab transfers
+    // silently, so without this it would stay stuck on "Press a key...").
+    if (s_activeCapture && s_activeCapture != this) {
+        s_activeCapture->endCapture();
+    }
+    s_activeCapture = this;
+
+    m_capturing = true;
+    setText(tr("Press a key..."));
+    // Grab the keyboard so the next keystroke reaches this button no matter
+    // where the window focus currently is.
+    setFocus(Qt::OtherFocusReason);
+    grabKeyboard();
+}
+
+void KeyCaptureButton::endCapture()
+{
+    if (s_activeCapture == this) {
+        s_activeCapture = nullptr;
+    }
+    m_capturing = false;
+    releaseKeyboard();
+    updateLabel();
+}
+
+void KeyCaptureButton::updateLabel()
+{
+    if (m_capturing) {
+        return;
+    }
+    setText(KbdJoy::keyDisplayName(m_encoded));
+}
+
+void KeyCaptureButton::keyPressEvent(QKeyEvent* event)
+{
+    if (!m_capturing) {
+        QPushButton::keyPressEvent(event);
+        return;
+    }
+
+    const int key = event->key();
+
+    if (key == Qt::Key_Escape) {
+        endCapture();
+        event->accept();
+        return;
+    }
+
+    if ((key == Qt::Key_Backspace || key == Qt::Key_Delete) && m_clearable) {
+        m_encoded = 0;
+        endCapture();
+        emit keyCaptured(0);
+        event->accept();
+        return;
+    }
+
+    // Ignore pure modifier presses — wait for a real key.
+    if (key == Qt::Key_Shift || key == Qt::Key_Control || key == Qt::Key_Alt
+        || key == Qt::Key_Meta || key == Qt::Key_AltGr || key == Qt::Key_unknown) {
+        event->accept();
+        return;
+    }
+
+    // Space/Return would normally re-trigger the button; while capturing they are bindings.
+    m_encoded = KbdJoy::encodeKey(key, (event->modifiers() & Qt::KeypadModifier) != 0);
+    endCapture();
+    emit keyCaptured(m_encoded);
+    event->accept();
+}
+
+void KeyCaptureButton::focusOutEvent(QFocusEvent* event)
+{
+    if (m_capturing) {
+        endCapture();
+    }
+    QPushButton::focusOutEvent(event);
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,6 +11,7 @@
 
 #include "mainwindow.h"
 #include "macosfullscreen.h"
+#include "keyboardjoystickmap.h"
 #include "version.h"  // For FUJISAN_FULL_VERSION_STRING
 #include <QApplication>
 #include <QAbstractScrollArea>
@@ -55,6 +56,9 @@ struct JoystickSettingsSnapshot {
     bool swap = false;
     QString preset0 = QStringLiteral("numpad");
     QString preset1 = QStringLiteral("wasd");
+    // Encoded custom key maps (keyboardjoystickmap.h); empty = derive from preset.
+    QString map0;
+    QString map1;
 };
 
 JoystickSettingsSnapshot readJoystickSettingsSnapshot(QSettings& settings)
@@ -68,6 +72,8 @@ JoystickSettingsSnapshot readJoystickSettingsSnapshot(QSettings& settings)
     sn.swap = settings.value(QStringLiteral("input/swapJoysticks"), false).toBool();
     sn.preset0 = settings.value(QStringLiteral("input/joystick1Preset"), QStringLiteral("numpad")).toString();
     sn.preset1 = settings.value(QStringLiteral("input/joystick2Preset"), QStringLiteral("wasd")).toString();
+    sn.map0 = settings.value(QStringLiteral("input/joy0KeyMap"), QString()).toString();
+    sn.map1 = settings.value(QStringLiteral("input/joy1KeyMap"), QString()).toString();
     sn.effKbd0 = sn.master && (sn.device1 == QStringLiteral("keyboard")) && kbd0Saved;
     sn.effKbd1 = sn.master && (sn.device2 == QStringLiteral("keyboard")) && kbd1Saved;
     return sn;
@@ -846,12 +852,12 @@ void MainWindow::createJoystickToolbarSection()
 
     m_kbdJoy0Check = new QCheckBox("Kbd J1");
     m_kbdJoy0Check->setStyleSheet("font-size: 10px;");
-    m_kbdJoy0Check->setToolTip("Enable keyboard joystick 1 (Numpad)");
+    m_kbdJoy0Check->setToolTip("Enable keyboard joystick 1");
     leftLayout->addWidget(m_kbdJoy0Check);
 
     m_kbdJoy1Check = new QCheckBox("Kbd J2");
     m_kbdJoy1Check->setStyleSheet("font-size: 10px;");
-    m_kbdJoy1Check->setToolTip("Enable keyboard joystick 2 (WASD)");
+    m_kbdJoy1Check->setToolTip("Enable keyboard joystick 2");
     leftLayout->addWidget(m_kbdJoy1Check);
 
     controlsLayout->addWidget(leftColumn);
@@ -948,6 +954,9 @@ void MainWindow::createJoystickToolbarSection()
     m_kbdJoy0Check->setChecked(port0Kb && joySettings.value(QStringLiteral("input/kbdJoy0Enabled"), false).toBool());
     m_kbdJoy1Check->setChecked(port1Kb && joySettings.value(QStringLiteral("input/kbdJoy1Enabled"), false).toBool());
     m_joystickSwapWidget->setSwapped(sn.swap);
+
+    // Show the effective key bindings in the tooltips (customizable in Settings -> Input)
+    updateKbdJoyKeyLabels();
 }
 
 void MainWindow::createAudioToolbarSection()
@@ -1566,7 +1575,8 @@ void MainWindow::restartEmulator()
         if (initSuccess) {
             m_emulator->applyJoystickInputBundle(sn.master, sn.device1, sn.device2,
                                                  sn.effKbd0, sn.effKbd1, sn.swap,
-                                                 sn.preset0, sn.preset1);
+                                                 sn.preset0, sn.preset1,
+                                                 sn.map0, sn.map1);
             m_emulator->setEmulationSpeed(speedPercentage);
         }
     };
@@ -1769,12 +1779,53 @@ void MainWindow::syncEmulatorJoystickFromQSettings()
                                   Q_ARG(bool, sn.effKbd1),
                                   Q_ARG(bool, sn.swap),
                                   Q_ARG(QString, sn.preset0),
-                                  Q_ARG(QString, sn.preset1));
+                                  Q_ARG(QString, sn.preset1),
+                                  Q_ARG(QString, sn.map0),
+                                  Q_ARG(QString, sn.map1));
     } else {
         m_emulator->applyJoystickInputBundle(sn.master, sn.device1, sn.device2,
                                              sn.effKbd0, sn.effKbd1, sn.swap,
-                                             sn.preset0, sn.preset1);
+                                             sn.preset0, sn.preset1,
+                                             sn.map0, sn.map1);
     }
+}
+
+void MainWindow::updateKbdJoyKeyLabels()
+{
+    if (!m_kbdJoy0Check || !m_kbdJoy1Check || !m_joystickSwapWidget) {
+        return;
+    }
+
+    QSettings settings(QStringLiteral("8bitrelics"), QStringLiteral("Fujisan"));
+    JoystickSettingsSnapshot sn = readJoystickSettingsSnapshot(settings);
+
+    auto mapFor = [](const QString& mapStr, const QString& preset) {
+        KbdJoy::KeyboardJoystickMap m;
+        if (!KbdJoy::decodeMapFromString(mapStr, m)) {
+            m = KbdJoy::mapForPreset(preset);
+        }
+        return m;
+    };
+    const KbdJoy::KeyboardJoystickMap m0 = mapFor(sn.map0, sn.preset0);
+    const KbdJoy::KeyboardJoystickMap m1 = mapFor(sn.map1, sn.preset1);
+
+    auto summary = [](const KbdJoy::KeyboardJoystickMap& m) -> QString {
+        return QStringLiteral("%1/%2/%3/%4, Fire: %5")
+            .arg(KbdJoy::keyDisplayName(m.up), KbdJoy::keyDisplayName(m.down),
+                 KbdJoy::keyDisplayName(m.left), KbdJoy::keyDisplayName(m.right),
+                 KbdJoy::keyDisplayName(m.fire));
+    };
+    m_kbdJoy0Check->setToolTip(QStringLiteral("Enable keyboard joystick 1 (%1)").arg(summary(m0)));
+    m_kbdJoy1Check->setToolTip(QStringLiteral("Enable keyboard joystick 2 (%1)").arg(summary(m1)));
+
+    auto lines = [](const KbdJoy::KeyboardJoystickMap& m) -> QStringList {
+        return { KbdJoy::keyDisplayName(m.up),
+                 QStringLiteral("%1 %2 %3").arg(KbdJoy::keyDisplayName(m.left),
+                                               KbdJoy::keyDisplayName(m.down),
+                                               KbdJoy::keyDisplayName(m.right)),
+                 KbdJoy::keyDisplayName(m.fire) };
+    };
+    m_joystickSwapWidget->setJoystickKeyLabels(lines(m0), lines(m1));
 }
 
 void MainWindow::updateToolbarFromSettings()
@@ -1872,6 +1923,8 @@ void MainWindow::updateToolbarFromSettings()
         m_kbdJoy1Check->blockSignals(false);
 
         m_joystickSwapWidget->setSwapped(sn.swap);
+
+        updateKbdJoyKeyLabels();
 
         syncEmulatorJoystickFromQSettings();
 
@@ -3321,7 +3374,8 @@ void MainWindow::loadInitialSettings()
         if (initSuccess) {
             m_emulator->applyJoystickInputBundle(sn.master, sn.device1, sn.device2,
                                                  sn.effKbd0, sn.effKbd1, sn.swap,
-                                                 sn.preset0, sn.preset1);
+                                                 sn.preset0, sn.preset1,
+                                                 sn.map0, sn.map1);
             m_emulator->setEmulationSpeed(speedPercentage);
         }
     }, Qt::BlockingQueuedConnection);
@@ -4034,6 +4088,8 @@ void MainWindow::applyProfileToEmulator(const ConfigurationProfile& profile, boo
         settings.setValue(QStringLiteral("input/joystick2Device"), pj2);
         settings.setValue(QStringLiteral("input/joystick1Preset"), profile.joystick1Preset);
         settings.setValue(QStringLiteral("input/joystick2Preset"), profile.joystick2Preset);
+        settings.setValue(QStringLiteral("input/joy0KeyMap"), profile.joystick1KeyMap);
+        settings.setValue(QStringLiteral("input/joy1KeyMap"), profile.joystick2KeyMap);
         settings.setValue(QStringLiteral("input/swapJoysticks"), profile.swapJoysticks);
         settings.setValue(QStringLiteral("input/kbdJoy0Enabled"), profile.kbdJoy0Enabled);
         settings.setValue(QStringLiteral("input/kbdJoy1Enabled"), profile.kbdJoy1Enabled);

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -17,6 +17,7 @@
 #include <QProcess>
 #include <QDir>
 #include <QTextStream>
+#include <QMap>
 
 #ifdef HAVE_SDL2_JOYSTICK
 #include "sdl2joystickmanager.h"
@@ -25,6 +26,7 @@
 #include "fujinetservice.h"
 #include "fujinetprocessmanager.h"
 #include "fujinetbinarymanager.h"
+#include "keycapturebutton.h"
 
 SettingsDialog::SettingsDialog(AtariEmulator* emulator, ConfigurationProfileManager* profileManager,
                                FujiNetService* fujinetService,
@@ -1408,17 +1410,14 @@ void SettingsDialog::createInputConfigTab()
     joy1Layout->addWidget(m_joystick1Device);
 
     m_joystick1Preset = new QComboBox();
-    m_joystick1Preset->setToolTip("Keyboard preset: Numpad, Arrows (Mac-friendly), or WASD");
+    m_joystick1Preset->setToolTip("Keyboard layout template; editing any key below switches to Custom");
     m_joystick1Preset->addItem("Numpad", "numpad");
     m_joystick1Preset->addItem("Arrows", "arrows");
     m_joystick1Preset->addItem("WASD", "wasd");
+    m_joystick1Preset->addItem("Custom", "custom");
     m_joystick1Preset->setVisible(false);
     joy1Layout->addWidget(m_joystick1Preset);
 
-    m_joystick1KeysLabel = new QLabel();
-    m_joystick1KeysLabel->setStyleSheet("QLabel { color: #666; font-style: italic; }");
-    m_joystick1KeysLabel->setVisible(false);
-    joy1Layout->addWidget(m_joystick1KeysLabel);
     joy1Layout->addStretch();
 
     deviceLayout->addRow("Joystick 1:", joy1Layout);
@@ -1430,23 +1429,36 @@ void SettingsDialog::createInputConfigTab()
     joy2Layout->addWidget(m_joystick2Device);
 
     m_joystick2Preset = new QComboBox();
-    m_joystick2Preset->setToolTip("Keyboard preset: Numpad, Arrows (Mac-friendly), or WASD");
+    m_joystick2Preset->setToolTip("Keyboard layout template; editing any key below switches to Custom");
     m_joystick2Preset->addItem("Numpad", "numpad");
     m_joystick2Preset->addItem("Arrows", "arrows");
     m_joystick2Preset->addItem("WASD", "wasd");
+    m_joystick2Preset->addItem("Custom", "custom");
     m_joystick2Preset->setVisible(false);
     joy2Layout->addWidget(m_joystick2Preset);
 
-    m_joystick2KeysLabel = new QLabel();
-    m_joystick2KeysLabel->setStyleSheet("QLabel { color: #666; font-style: italic; }");
-    m_joystick2KeysLabel->setVisible(false);
-    joy2Layout->addWidget(m_joystick2KeysLabel);
     joy2Layout->addStretch();
 
     deviceLayout->addRow("Joystick 2:", joy2Layout);
 
     joystickLayout->addLayout(deviceLayout);
     joystickLayout->addSpacing(10);
+
+    // Per-joystick key binding grids (fire + 8 directions)
+    QHBoxLayout* gridsLayout = new QHBoxLayout();
+    m_joystick1KeysWidget = createKeyBindingGrid(1);
+    m_joystick2KeysWidget = createKeyBindingGrid(2);
+    m_joystick1KeysWidget->setVisible(false);
+    m_joystick2KeysWidget->setVisible(false);
+    gridsLayout->addWidget(m_joystick1KeysWidget);
+    gridsLayout->addWidget(m_joystick2KeysWidget);
+    gridsLayout->addStretch();
+    joystickLayout->addLayout(gridsLayout);
+
+    m_keyConflictLabel = new QLabel();
+    m_keyConflictLabel->setStyleSheet("QLabel { color: #c00; font-style: italic; }");
+    m_keyConflictLabel->setVisible(false);
+    joystickLayout->addWidget(m_keyConflictLabel);
 
     m_swapJoysticks = new QCheckBox("Swap joystick assignments");
     m_swapJoysticks->setToolTip("Swap the assignments between Joystick 1 and Joystick 2");
@@ -1487,16 +1499,13 @@ void SettingsDialog::createInputConfigTab()
         m_joystick1Preset->setEnabled(enabled);
         m_joystick2Preset->setEnabled(enabled);
         m_swapJoysticks->setEnabled(enabled);
-        m_joystick1KeysLabel->setEnabled(enabled);
-        m_joystick2KeysLabel->setEnabled(enabled);
+        m_joystick1KeysWidget->setEnabled(enabled);
+        m_joystick2KeysWidget->setEnabled(enabled);
     });
 
+    // Preset combo = layout template: selecting one fills the binding grid
     connect(m_joystick1Preset, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]() { onJoystickPresetChanged(1); });
     connect(m_joystick2Preset, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]() { onJoystickPresetChanged(2); });
-    connect(m_joystick1Preset, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsDialog::updateKeyboardMappingLabels);
-    connect(m_joystick2Preset, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsDialog::updateKeyboardMappingLabels);
-    connect(m_joystick1Preset, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsDialog::onJoystickDeviceChanged);
-    connect(m_joystick2Preset, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SettingsDialog::onJoystickDeviceChanged);
 
     // Note: Joystick refresh is handled by event filter on dropdown open
     // This prevents signal re-entrancy issues during refresh
@@ -1504,6 +1513,10 @@ void SettingsDialog::createInputConfigTab()
     // Install event filters to refresh joysticks when dropdown opens
     m_joystick1Device->installEventFilter(this);
     m_joystick2Device->installEventFilter(this);
+
+    // Initial binding grids: historical defaults (loadSettings may override below)
+    setJoyMapButtons(1, KbdJoy::KeyboardJoystickMap::numpadPreset());
+    setJoyMapButtons(2, KbdJoy::KeyboardJoystickMap::wasdPreset());
 
     // Initialize joystick device dropdowns
     populateJoystickDevices();
@@ -2728,7 +2741,7 @@ void SettingsDialog::loadSettings()
     m_grabMouse->setChecked(settings.value("input/grabMouse", false).toBool());
     m_mouseDevice->setText(settings.value("input/mouseDevice", "").toString());
 
-    // Load joystick keyboard presets
+    // Load joystick keyboard presets ("custom" when the user remapped keys)
     QString joystick1Preset = settings.value("input/joystick1Preset", "numpad").toString();
     QString joystick2Preset = settings.value("input/joystick2Preset", "wasd").toString();
     for (int i = 0; m_joystick1Preset && i < m_joystick1Preset->count(); ++i) {
@@ -2744,24 +2757,34 @@ void SettingsDialog::loadSettings()
         }
     }
 
+    // Load custom key maps; fall back to the preset layout when absent/invalid
+    {
+        KbdJoy::KeyboardJoystickMap map1, map2;
+        if (!KbdJoy::decodeMapFromString(settings.value("input/joy0KeyMap", "").toString(), map1)) {
+            map1 = KbdJoy::isValidPresetName(joystick1Preset)
+                 ? KbdJoy::mapForPreset(joystick1Preset)
+                 : KbdJoy::KeyboardJoystickMap::numpadPreset();
+        }
+        if (!KbdJoy::decodeMapFromString(settings.value("input/joy1KeyMap", "").toString(), map2)) {
+            map2 = KbdJoy::isValidPresetName(joystick2Preset)
+                 ? KbdJoy::mapForPreset(joystick2Preset)
+                 : KbdJoy::KeyboardJoystickMap::wasdPreset();
+        }
+        setJoyMapButtons(1, map1);
+        setJoyMapButtons(2, map2);
+    }
+
     // Enable/disable dependent controls based on main joystick state
     m_joystick1Device->setEnabled(mainJoystickEnabled);
     m_joystick2Device->setEnabled(mainJoystickEnabled);
     m_joystick1Preset->setEnabled(mainJoystickEnabled);
     m_joystick2Preset->setEnabled(mainJoystickEnabled);
     m_swapJoysticks->setEnabled(mainJoystickEnabled);
+    m_joystick1KeysWidget->setEnabled(mainJoystickEnabled);
+    m_joystick2KeysWidget->setEnabled(mainJoystickEnabled);
 
-    // Update keyboard mapping labels (preset visibility)
+    // Update keyboard mapping grids visibility + conflict warning
     updateKeyboardMappingLabels();
-
-    // Resolve preset conflict if both joysticks use keyboard and same preset
-    if (mainJoystickEnabled && joystick1Device == "keyboard" && joystick2Device == "keyboard") {
-        QString p1 = m_joystick1Preset ? m_joystick1Preset->currentData().toString() : "numpad";
-        QString p2 = m_joystick2Preset ? m_joystick2Preset->currentData().toString() : "wasd";
-        if (p1 == p2) {
-            onJoystickPresetChanged(1);
-        }
-    }
     
     // Load Media Configuration
     // Floppy Disks
@@ -2968,6 +2991,8 @@ void SettingsDialog::saveSettings()
     settings.setValue("input/joystick2Device", m_joystick2Device->currentData().toString());
     settings.setValue("input/joystick1Preset", m_joystick1Preset ? m_joystick1Preset->currentData().toString() : "numpad");
     settings.setValue("input/joystick2Preset", m_joystick2Preset ? m_joystick2Preset->currentData().toString() : "wasd");
+    settings.setValue("input/joy0KeyMap", KbdJoy::encodeMapToString(currentJoyMap(1)));
+    settings.setValue("input/joy1KeyMap", KbdJoy::encodeMapToString(currentJoyMap(2)));
 
     {
         const QString d1 = m_joystick1Device->currentData().toString();
@@ -3279,7 +3304,9 @@ void SettingsDialog::applySettings()
                                   Q_ARG(bool, kbd1),
                                   Q_ARG(bool, swapped),
                                   Q_ARG(QString, presetJoy1),
-                                  Q_ARG(QString, presetJoy2));
+                                  Q_ARG(QString, presetJoy2),
+                                  Q_ARG(QString, KbdJoy::encodeMapToString(currentJoyMap(1))),
+                                  Q_ARG(QString, KbdJoy::encodeMapToString(currentJoyMap(2))));
 
         qDebug() << "Applied joystick settings live - MainJoystick:" << mainJoystickEnabled
                  << "Swap:" << swapped;
@@ -3721,6 +3748,23 @@ void SettingsDialog::restoreDefaults()
     m_joystick1Device->setCurrentIndex(0); // "Keyboard"
     m_joystick2Device->setCurrentIndex(0); // "Keyboard"
 
+    // Default keyboard layouts: Joy1=Numpad, Joy2=WASD
+    for (int i = 0; i < m_joystick1Preset->count(); ++i) {
+        if (m_joystick1Preset->itemData(i).toString() == QStringLiteral("numpad")) {
+            m_joystick1Preset->setCurrentIndex(i);
+            break;
+        }
+    }
+    for (int i = 0; i < m_joystick2Preset->count(); ++i) {
+        if (m_joystick2Preset->itemData(i).toString() == QStringLiteral("wasd")) {
+            m_joystick2Preset->setCurrentIndex(i);
+            break;
+        }
+    }
+    setJoyMapButtons(1, KbdJoy::KeyboardJoystickMap::numpadPreset());
+    setJoyMapButtons(2, KbdJoy::KeyboardJoystickMap::wasdPreset());
+    updateKeyConflictWarning();
+
     m_swapJoysticks->setChecked(false);  // Default false: Joy0=Numpad, Joy1=WASD
     m_grabMouse->setChecked(false);
     m_mouseDevice->clear();
@@ -3932,6 +3976,8 @@ ConfigurationProfile SettingsDialog::getCurrentUIState() const
     }
     profile.joystick1Preset = m_joystick1Preset ? m_joystick1Preset->currentData().toString() : "numpad";
     profile.joystick2Preset = m_joystick2Preset ? m_joystick2Preset->currentData().toString() : "wasd";
+    profile.joystick1KeyMap = KbdJoy::encodeMapToString(currentJoyMap(1));
+    profile.joystick2KeyMap = KbdJoy::encodeMapToString(currentJoyMap(2));
     profile.swapJoysticks = m_swapJoysticks->isChecked();
     profile.grabMouse = m_grabMouse->isChecked();
     profile.mouseDevice = m_mouseDevice->text();
@@ -4232,8 +4278,23 @@ void SettingsDialog::loadProfileToUI(const ConfigurationProfile& profile)
             break;
         }
     }
-    if (profile.kbdJoy0Enabled && profile.kbdJoy1Enabled) {
-        onJoystickPresetChanged(1);  // Resolve conflict if both presets ended up the same
+
+    // Key maps from the profile; fall back to preset layouts for old profiles
+    {
+        KbdJoy::KeyboardJoystickMap map1, map2;
+        if (!KbdJoy::decodeMapFromString(profile.joystick1KeyMap, map1)) {
+            map1 = KbdJoy::isValidPresetName(profile.joystick1Preset)
+                 ? KbdJoy::mapForPreset(profile.joystick1Preset)
+                 : KbdJoy::KeyboardJoystickMap::numpadPreset();
+        }
+        if (!KbdJoy::decodeMapFromString(profile.joystick2KeyMap, map2)) {
+            map2 = KbdJoy::isValidPresetName(profile.joystick2Preset)
+                 ? KbdJoy::mapForPreset(profile.joystick2Preset)
+                 : KbdJoy::KeyboardJoystickMap::wasdPreset();
+        }
+        setJoyMapButtons(1, map1);
+        setJoyMapButtons(2, map2);
+        updateKeyConflictWarning();
     }
 
     // Cartridge Configuration
@@ -4445,40 +4506,169 @@ void SettingsDialog::updateKeyboardMappingLabels()
         return;
     }
 
-    QString device1 = m_joystick1Device->currentData().toString();
-    QString device2 = m_joystick2Device->currentData().toString();
-    QString preset1 = m_joystick1Preset ? m_joystick1Preset->currentData().toString() : "numpad";
-    QString preset2 = m_joystick2Preset ? m_joystick2Preset->currentData().toString() : "wasd";
+    const QString device1 = m_joystick1Device->currentData().toString();
+    const QString device2 = m_joystick2Device->currentData().toString();
 
-    // Labels based on preset (not swap - preset is per slot)
-    auto presetToKeys = [](const QString& preset) -> QString {
-        if (preset == "numpad") return "Keys: ↑ ← ↓ → + Numpad Enter";
-        if (preset == "arrows") return "Keys: ↑ ← ↓ → + Return";
-        if (preset == "wasd") return "Keys: W A S D + Space";
-        return "Keys: ?";
+    // Show/hide preset combos and binding grids based on device selection
+    const bool kbd1 = (device1 == QStringLiteral("keyboard"));
+    const bool kbd2 = (device2 == QStringLiteral("keyboard"));
+    m_joystick1Preset->setVisible(kbd1);
+    m_joystick1KeysWidget->setVisible(kbd1);
+    m_joystick2Preset->setVisible(kbd2);
+    m_joystick2KeysWidget->setVisible(kbd2);
+
+    updateKeyConflictWarning();
+}
+
+QWidget* SettingsDialog::createKeyBindingGrid(int joy)
+{
+    QGroupBox* box = new QGroupBox(tr("Joystick %1 Keys").arg(joy));
+    QGridLayout* grid = new QGridLayout(box);
+
+    // Two columns: cardinals + fire on the left, optional diagonals on the right.
+    // Index order must match the m_joyNKeyButtons convention:
+    // 0=up, 1=down, 2=left, 3=right, 4=ul, 5=ur, 6=ll, 7=lr, 8=fire.
+    struct Row { int binding; const char* label; };
+    static const Row leftColumn[5] = {
+        { 0, "Up:" }, { 1, "Down:" }, { 2, "Left:" }, { 3, "Right:" }, { 8, "Fire:" }
+    };
+    static const Row rightColumn[4] = {
+        { 4, "Up-Left:" }, { 5, "Up-Right:" }, { 6, "Down-Left:" }, { 7, "Down-Right:" }
     };
 
-    QString joy1Keys = presetToKeys(preset1);
-    QString joy2Keys = presetToKeys(preset2);
+    KeyCaptureButton** buttons = (joy == 1) ? m_joy1KeyButtons : m_joy2KeyButtons;
 
-    // Show/hide preset and labels based on device selection
-    if (device1 == "keyboard") {
-        m_joystick1Preset->setVisible(true);
-        m_joystick1KeysLabel->setText(joy1Keys);
-        m_joystick1KeysLabel->setVisible(true);
-    } else {
-        m_joystick1Preset->setVisible(false);
-        m_joystick1KeysLabel->setVisible(false);
+    auto addRow = [this, grid, buttons, joy](const Row& row, int gridRow, int gridCol, bool clearable) {
+        QLabel* label = new QLabel(tr(row.label));
+        KeyCaptureButton* button = new KeyCaptureButton();
+        button->setClearable(clearable);
+        if (clearable) {
+            button->setToolTip(tr("Optional: dedicated diagonal key. Backspace/Delete clears it; "
+                                  "diagonals also work by holding two direction keys."));
+        }
+        grid->addWidget(label, gridRow, gridCol);
+        grid->addWidget(button, gridRow, gridCol + 1);
+        buttons[row.binding] = button;
+        connect(button, &KeyCaptureButton::keyCaptured, this, [this, joy](int) {
+            onKeyBindingCaptured(joy);
+        });
+    };
+
+    for (int i = 0; i < 5; ++i) {
+        addRow(leftColumn[i], i, 0, false);
+    }
+    for (int i = 0; i < 4; ++i) {
+        addRow(rightColumn[i], i, 2, true);
     }
 
-    if (device2 == "keyboard") {
-        m_joystick2Preset->setVisible(true);
-        m_joystick2KeysLabel->setText(joy2Keys);
-        m_joystick2KeysLabel->setVisible(true);
-    } else {
-        m_joystick2Preset->setVisible(false);
-        m_joystick2KeysLabel->setVisible(false);
+    return box;
+}
+
+KbdJoy::KeyboardJoystickMap SettingsDialog::currentJoyMap(int joy) const
+{
+    KeyCaptureButton* const* buttons = (joy == 1) ? m_joy1KeyButtons : m_joy2KeyButtons;
+    KbdJoy::KeyboardJoystickMap map;
+    if (!buttons[0]) {
+        return map;
     }
+    map.up = buttons[0]->encodedKey();
+    map.down = buttons[1]->encodedKey();
+    map.left = buttons[2]->encodedKey();
+    map.right = buttons[3]->encodedKey();
+    map.ul = buttons[4]->encodedKey();
+    map.ur = buttons[5]->encodedKey();
+    map.ll = buttons[6]->encodedKey();
+    map.lr = buttons[7]->encodedKey();
+    map.fire = buttons[8]->encodedKey();
+    return map;
+}
+
+void SettingsDialog::setJoyMapButtons(int joy, const KbdJoy::KeyboardJoystickMap& map)
+{
+    KeyCaptureButton** buttons = (joy == 1) ? m_joy1KeyButtons : m_joy2KeyButtons;
+    if (!buttons[0]) {
+        return;
+    }
+    const int values[9] = { map.up, map.down, map.left, map.right,
+                            map.ul, map.ur, map.ll, map.lr, map.fire };
+    for (int i = 0; i < 9; ++i) {
+        buttons[i]->setEncodedKey(values[i]);
+    }
+}
+
+void SettingsDialog::onKeyBindingCaptured(int joy)
+{
+    // Reflect the (possibly new) layout in the preset combo
+    QComboBox* presetCombo = (joy == 1) ? m_joystick1Preset : m_joystick2Preset;
+    const QString preset = KbdJoy::presetNameForMap(currentJoyMap(joy));
+    presetCombo->blockSignals(true);
+    for (int i = 0; i < presetCombo->count(); ++i) {
+        if (presetCombo->itemData(i).toString() == preset) {
+            presetCombo->setCurrentIndex(i);
+            break;
+        }
+    }
+    presetCombo->blockSignals(false);
+
+    updateKeyConflictWarning();
+    onJoystickDeviceChanged();  // live apply
+}
+
+void SettingsDialog::updateKeyConflictWarning()
+{
+    if (!m_keyConflictLabel) {
+        return;
+    }
+
+    // Collect bindings per joystick: encoded key -> description
+    auto bindingsOf = [](const KbdJoy::KeyboardJoystickMap& m) -> QMap<int, QString> {
+        QMap<int, QString> b;
+        b.insert(m.up, QStringLiteral("Up"));
+        b.insert(m.down, QStringLiteral("Down"));
+        b.insert(m.left, QStringLiteral("Left"));
+        b.insert(m.right, QStringLiteral("Right"));
+        if (m.ul) b.insert(m.ul, QStringLiteral("Up-Left"));
+        if (m.ur) b.insert(m.ur, QStringLiteral("Up-Right"));
+        if (m.ll) b.insert(m.ll, QStringLiteral("Down-Left"));
+        if (m.lr) b.insert(m.lr, QStringLiteral("Down-Right"));
+        b.insert(m.fire, QStringLiteral("Fire"));
+        return b;
+    };
+
+    const KbdJoy::KeyboardJoystickMap map1 = currentJoyMap(1);
+    const KbdJoy::KeyboardJoystickMap map2 = currentJoyMap(2);
+    const QMap<int, QString> b1 = bindingsOf(map1);
+    const QMap<int, QString> b2 = bindingsOf(map2);
+
+    QStringList warnings;
+
+    // Duplicates within one joystick (QMap keeps only the last entry per key)
+    const int count1 = (map1.ul ? 1 : 0) + (map1.ur ? 1 : 0) + (map1.ll ? 1 : 0) + (map1.lr ? 1 : 0) + 5;
+    const int count2 = (map2.ul ? 1 : 0) + (map2.ur ? 1 : 0) + (map2.ll ? 1 : 0) + (map2.lr ? 1 : 0) + 5;
+    if (b1.size() < count1) {
+        warnings << tr("Joystick 1 assigns the same key to multiple actions");
+    }
+    if (b2.size() < count2) {
+        warnings << tr("Joystick 2 assigns the same key to multiple actions");
+    }
+
+    // Overlap across joysticks (only relevant when both are keyboard-driven)
+    const bool bothKbd = m_joystick1Device->currentData().toString() == QStringLiteral("keyboard")
+                      && m_joystick2Device->currentData().toString() == QStringLiteral("keyboard");
+    if (bothKbd) {
+        QStringList shared;
+        for (auto it = b1.constBegin(); it != b1.constEnd(); ++it) {
+            if (b2.contains(it.key())) {
+                shared << KbdJoy::keyDisplayName(it.key());
+            }
+        }
+        if (!shared.isEmpty()) {
+            warnings << tr("Keys used by both joysticks: %1").arg(shared.join(QStringLiteral(", ")));
+        }
+    }
+
+    m_keyConflictLabel->setVisible(!warnings.isEmpty());
+    m_keyConflictLabel->setText(warnings.join(QStringLiteral("  •  ")));
 }
 
 void SettingsDialog::onJoystickDeviceChanged()
@@ -4493,6 +4683,8 @@ void SettingsDialog::onJoystickDeviceChanged()
     const QString device2 = m_joystick2Device->currentData().toString();
     const QString preset1 = m_joystick1Preset ? m_joystick1Preset->currentData().toString() : QStringLiteral("numpad");
     const QString preset2 = m_joystick2Preset ? m_joystick2Preset->currentData().toString() : QStringLiteral("wasd");
+    const QString map1 = KbdJoy::encodeMapToString(currentJoyMap(1));
+    const QString map2 = KbdJoy::encodeMapToString(currentJoyMap(2));
     const bool swapped = m_swapJoysticks->isChecked();
     const bool kbd0 = mainJoystickEnabled && (device1 == QStringLiteral("keyboard")) &&
                       st.value(QStringLiteral("input/kbdJoy0Enabled"), false).toBool();
@@ -4509,43 +4701,22 @@ void SettingsDialog::onJoystickDeviceChanged()
                               Q_ARG(bool, kbd1),
                               Q_ARG(bool, swapped),
                               Q_ARG(QString, preset1),
-                              Q_ARG(QString, preset2));
+                              Q_ARG(QString, preset2),
+                              Q_ARG(QString, map1),
+                              Q_ARG(QString, map2));
 }
 
 void SettingsDialog::onJoystickPresetChanged(int joystickNumber)
 {
-    if (!m_joystick1Preset || !m_joystick2Preset) return;
+    QComboBox* combo = (joystickNumber == 1) ? m_joystick1Preset : m_joystick2Preset;
+    if (!combo) return;
 
-    // Only apply when both joysticks use keyboard
-    QString device1 = m_joystick1Device->currentData().toString();
-    QString device2 = m_joystick2Device->currentData().toString();
-    if (device1 != "keyboard" || device2 != "keyboard") return;
-
-    QString preset1 = m_joystick1Preset->currentData().toString();
-    QString preset2 = m_joystick2Preset->currentData().toString();
-    if (preset1 != preset2) return;  // No conflict
-
-    // Pick alternate preset: numpad -> arrows -> wasd -> numpad
-    auto alternatePreset = [](const QString& p) -> QString {
-        if (p == "numpad") return "arrows";
-        if (p == "arrows") return "wasd";
-        return "numpad";
-    };
-
-    QString newPreset = alternatePreset(preset1);
-    QComboBox* otherCombo = (joystickNumber == 1) ? m_joystick2Preset : m_joystick1Preset;
-
-    otherCombo->blockSignals(true);
-    for (int i = 0; i < otherCombo->count(); ++i) {
-        if (otherCombo->itemData(i).toString() == newPreset) {
-            otherCombo->setCurrentIndex(i);
-            break;
-        }
+    // "Custom" just keeps the current bindings; templates fill the grid
+    const QString preset = combo->currentData().toString();
+    if (preset != QStringLiteral("custom")) {
+        setJoyMapButtons(joystickNumber, KbdJoy::mapForPreset(preset));
     }
-    otherCombo->blockSignals(false);
 
-    // Other combo's signals will update labels and apply; do it explicitly in case
-    // we're in a scenario where the programmatic change doesn't emit
     updateKeyboardMappingLabels();
     onJoystickDeviceChanged();
 }

--- a/tests/test_profiles.cpp
+++ b/tests/test_profiles.cpp
@@ -78,6 +78,8 @@ private:
         p.kbdJoy1Enabled = true;
         p.joystick1Preset = "arrows";
         p.joystick2Preset = "numpad";
+        p.joystick1KeyMap = QStringLiteral("16777235,16777237,16777234,16777236,0,0,0,0,16777220");
+        p.joystick2KeyMap = QStringLiteral("87,83,65,68,81,69,90,67,32");
 
         p.primaryCartridge.enabled = true;
         p.primaryCartridge.path = "/carts/game.car";
@@ -188,6 +190,8 @@ private slots:
         QCOMPARE(loaded.kbdJoy1Enabled, original.kbdJoy1Enabled);
         QCOMPARE(loaded.joystick1Preset, original.joystick1Preset);
         QCOMPARE(loaded.joystick2Preset, original.joystick2Preset);
+        QCOMPARE(loaded.joystick1KeyMap, original.joystick1KeyMap);
+        QCOMPARE(loaded.joystick2KeyMap, original.joystick2KeyMap);
 
         QCOMPARE(loaded.primaryCartridge.enabled, original.primaryCartridge.enabled);
         QCOMPARE(loaded.primaryCartridge.path, original.primaryCartridge.path);


### PR DESCRIPTION
Both keyboard joysticks are now user-remappable: the fire button and all 8
Atari joystick directions (Up/Down/Left/Right plus the 4 diagonals), via
click-to-capture key buttons in Settings > Input Configuration.

- New KbdJoy::KeyboardJoystickMap (keyboardjoystickmap.h): 9 bindings per
  joystick encoded as Qt::Key + numpad-modifier flag, with preset expansion,
  string (de)serialization and display names shared by all UI.
- AtariEmulator: handleJoystickKeyboardEmulation() rewritten data-driven,
  replacing the three hardcoded numpad/arrows/wasd switch-blocks. Per-joystick
  pressed-key state replaces function-statics and resets on remap. Diagonal
  bindings are optional; unbound diagonals still work as two-key combos.
  applyJoystickInputBundle() extended to carry both key maps.
- Settings dialog: per-joystick binding grid (cardinals + fire in one column,
  diagonals in the other) using the new KeyCaptureButton (click, press key;
  Escape cancels; Backspace/Delete clears optional diagonals). Preset combos
  become layout templates; editing a key switches to "Custom". Inline warning
  for keys bound multiple times within or across joysticks. Replaces the old
  same-preset auto-rotation.
- Persistence: input/joy0KeyMap / input/joy1KeyMap in QSettings and new
  joystick1KeyMap / joystick2KeyMap profile fields (JSON). Old settings and
  profiles without stored maps expand from their preset, so behavior is
  unchanged for existing users (Joy1=Numpad, Joy2=WASD defaults).
- Toolbar Kbd J1/J2 tooltips and JoystickSwapWidget labels now reflect the
  active bindings; TCP/debug joystick status gains a keyboard_map summary.
- KeyCaptureButton: StrongFocus policy + keyboard grab while armed so macOS
  push buttons actually receive the captured keystroke.
- Tests: profile round-trip covers the new key-map fields.
- Docs: KEYBOARD_SHORTCUTS.md documents customization and defaults.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable keyboard joystick bindings for both joysticks.
  * Added key-capture controls for directions, diagonals, and fire buttons.
  * Added Numpad, arrow-key, WASD, and Custom mapping presets.
  * Added duplicate-binding warnings and support for saving mappings in profiles.
  * Updated joystick labels and tooltips to show active key bindings.

* **Documentation**
  * Expanded keyboard shortcut documentation with remapping and persistence instructions.

* **Tests**
  * Added profile round-trip coverage for custom joystick mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->